### PR TITLE
chore(deps): consolidate Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,13 +1,19 @@
 version: 2
+
+multi-ecosystem-groups:
+  dependencies:
+    schedule:
+      interval: weekly
+
 updates:
   - package-ecosystem: cargo
     directory: /
-    schedule:
-      interval: weekly
-    open-pull-requests-limit: 5
+    patterns:
+      - "*"
+    multi-ecosystem-group: dependencies
 
   - package-ecosystem: github-actions
     directory: /
-    schedule:
-      interval: weekly
-    open-pull-requests-limit: 5
+    patterns:
+      - "*"
+    multi-ecosystem-group: dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     name: Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions-rust-lang/setup-rust-toolchain@a0b538fa0b742a6aa35d6e2c169b4bd06d225a98 # v1
         with:
           components: rustfmt
@@ -33,7 +33,7 @@ jobs:
     name: TOML format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install taplo
         uses: taiki-e/install-action@50414676f9f5d50a65992c6dd2ed02641263226c # taplo-cli
         with:
@@ -45,7 +45,7 @@ jobs:
     name: Rust file line cap
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Test Rust file line checker
         run: scripts/test-rust-file-lines.sh
       - name: Enforce Rust file line cap (zero exceptions)
@@ -55,7 +55,7 @@ jobs:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions-rust-lang/setup-rust-toolchain@a0b538fa0b742a6aa35d6e2c169b4bd06d225a98 # v1
         with:
           components: clippy
@@ -77,7 +77,7 @@ jobs:
     name: Unused dependencies
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions-rust-lang/setup-rust-toolchain@a0b538fa0b742a6aa35d6e2c169b4bd06d225a98 # v1
       - name: Install cargo-machete
         uses: taiki-e/install-action@50414676f9f5d50a65992c6dd2ed02641263226c # cargo-machete
@@ -90,7 +90,7 @@ jobs:
     name: Shared field identity
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions-rust-lang/setup-rust-toolchain@a0b538fa0b742a6aa35d6e2c169b4bd06d225a98 # v1
       - name: Require one jolt-field identity and no akita-field
         run: scripts/check-shared-field-identity.sh
@@ -99,7 +99,7 @@ jobs:
     name: Documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions-rust-lang/setup-rust-toolchain@a0b538fa0b742a6aa35d6e2c169b4bd06d225a98 # v1
       - name: Build documentation
         run: cargo doc -q --release --no-deps --no-default-features --features parallel,disk-persistence,transcript-blake2b
@@ -114,7 +114,7 @@ jobs:
       matrix:
         shard: [1, 2]
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions-rust-lang/setup-rust-toolchain@a0b538fa0b742a6aa35d6e2c169b4bd06d225a98 # v1
         with:
           cache: false
@@ -163,7 +163,7 @@ jobs:
     name: Schedule artifact drift
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions-rust-lang/setup-rust-toolchain@a0b538fa0b742a6aa35d6e2c169b4bd06d225a98 # v1
         with:
           cache: false
@@ -216,7 +216,7 @@ jobs:
       matrix:
         backend: [transcript-blake2b, transcript-keccak]
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions-rust-lang/setup-rust-toolchain@a0b538fa0b742a6aa35d6e2c169b4bd06d225a98 # v1
       - name: Run semantic transcript suites
         run: >-
@@ -254,7 +254,7 @@ jobs:
     if: always() && needs.test.result != 'cancelled'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Test timing script fixtures
         run: python3 -m unittest discover -s scripts/tests -p "test_*.py"
       - name: Download test shard artifacts
@@ -332,7 +332,7 @@ jobs:
     name: Typos
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Check spelling
         uses: crate-ci/typos@6ac2ebd1b93eade61faf7e12688ad87a073fea59 # v1.46.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     name: Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
       - uses: actions-rust-lang/setup-rust-toolchain@a0b538fa0b742a6aa35d6e2c169b4bd06d225a98 # v1
         with:
           components: rustfmt
@@ -33,7 +33,7 @@ jobs:
     name: TOML format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
       - name: Install taplo
         uses: taiki-e/install-action@50414676f9f5d50a65992c6dd2ed02641263226c # taplo-cli
         with:
@@ -45,7 +45,7 @@ jobs:
     name: Rust file line cap
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
       - name: Test Rust file line checker
         run: scripts/test-rust-file-lines.sh
       - name: Enforce Rust file line cap (zero exceptions)
@@ -55,7 +55,7 @@ jobs:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
       - uses: actions-rust-lang/setup-rust-toolchain@a0b538fa0b742a6aa35d6e2c169b4bd06d225a98 # v1
         with:
           components: clippy
@@ -77,7 +77,7 @@ jobs:
     name: Unused dependencies
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
       - uses: actions-rust-lang/setup-rust-toolchain@a0b538fa0b742a6aa35d6e2c169b4bd06d225a98 # v1
       - name: Install cargo-machete
         uses: taiki-e/install-action@50414676f9f5d50a65992c6dd2ed02641263226c # cargo-machete
@@ -90,7 +90,7 @@ jobs:
     name: Shared field identity
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
       - uses: actions-rust-lang/setup-rust-toolchain@a0b538fa0b742a6aa35d6e2c169b4bd06d225a98 # v1
       - name: Require one jolt-field identity and no akita-field
         run: scripts/check-shared-field-identity.sh
@@ -99,7 +99,7 @@ jobs:
     name: Documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
       - uses: actions-rust-lang/setup-rust-toolchain@a0b538fa0b742a6aa35d6e2c169b4bd06d225a98 # v1
       - name: Build documentation
         run: cargo doc -q --release --no-deps --no-default-features --features parallel,disk-persistence,transcript-blake2b
@@ -114,7 +114,7 @@ jobs:
       matrix:
         shard: [1, 2]
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
       - uses: actions-rust-lang/setup-rust-toolchain@a0b538fa0b742a6aa35d6e2c169b4bd06d225a98 # v1
         with:
           cache: false
@@ -163,7 +163,7 @@ jobs:
     name: Schedule artifact drift
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
       - uses: actions-rust-lang/setup-rust-toolchain@a0b538fa0b742a6aa35d6e2c169b4bd06d225a98 # v1
         with:
           cache: false
@@ -216,7 +216,7 @@ jobs:
       matrix:
         backend: [transcript-blake2b, transcript-keccak]
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
       - uses: actions-rust-lang/setup-rust-toolchain@a0b538fa0b742a6aa35d6e2c169b4bd06d225a98 # v1
       - name: Run semantic transcript suites
         run: >-
@@ -254,7 +254,7 @@ jobs:
     if: always() && needs.test.result != 'cancelled'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
       - name: Test timing script fixtures
         run: python3 -m unittest discover -s scripts/tests -p "test_*.py"
       - name: Download test shard artifacts
@@ -332,7 +332,7 @@ jobs:
     name: Typos
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
       - name: Check spelling
         uses: crate-ci/typos@6ac2ebd1b93eade61faf7e12688ad87a073fea59 # v1.46.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,7 +152,7 @@ jobs:
           exit "$status"
       - name: Upload test shard artifact
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ci-test-pass-shard-${{ matrix.shard }}
           path: ${{ runner.temp }}/ci-test-pass-shard-${{ matrix.shard }}
@@ -312,7 +312,7 @@ jobs:
           fi
       - name: Upload test timing artifact
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ci-test-timing-data
           path: ${{ runner.temp }}/ci-test-timing-artifact

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,7 @@ jobs:
         with:
           cache: false
       - name: Cache Rust build artifacts
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           shared-key: ci-test-release
           add-job-id-key: false
@@ -169,7 +169,7 @@ jobs:
           cache: false
           components: rustfmt
       - name: Cache Rust build artifacts
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           shared-key: ci-test-schedule-artifact-drift
           add-job-id-key: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,7 +259,7 @@ jobs:
         run: python3 -m unittest discover -s scripts/tests -p "test_*.py"
       - name: Download test shard artifacts
         continue-on-error: true
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: ci-test-pass-shard-*
           merge-multiple: true

--- a/.github/workflows/doc-blast-radius-comment.yml
+++ b/.github/workflows/doc-blast-radius-comment.yml
@@ -19,7 +19,7 @@ jobs:
   comment:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/doc-blast-radius-comment.yml
+++ b/.github/workflows/doc-blast-radius-comment.yml
@@ -19,7 +19,7 @@ jobs:
   comment:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 

--- a/.github/workflows/doc-blast-radius-comment.yml
+++ b/.github/workflows/doc-blast-radius-comment.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Upsert PR comment
         if: github.event.pull_request.head.repo.full_name == github.repository
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           AKITA_DOC_BLAST_RADIUS_COMMENT: ${{ runner.temp }}/doc-blast-radius-comment.md
         with:

--- a/.github/workflows/doc-guardrails.yml
+++ b/.github/workflows/doc-guardrails.yml
@@ -14,7 +14,7 @@ jobs:
     name: Doc guardrails
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install ripgrep
         uses: taiki-e/install-action@50414676f9f5d50a65992c6dd2ed02641263226c # ripgrep

--- a/.github/workflows/doc-guardrails.yml
+++ b/.github/workflows/doc-guardrails.yml
@@ -14,7 +14,7 @@ jobs:
     name: Doc guardrails
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
 
       - name: Install ripgrep
         uses: taiki-e/install-action@50414676f9f5d50a65992c6dd2ed02641263226c # ripgrep

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -33,7 +33,7 @@ jobs:
     name: Fuzz Akita targets
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
       - uses: actions-rust-lang/setup-rust-toolchain@a0b538fa0b742a6aa35d6e2c169b4bd06d225a98 # v1
         with:
           toolchain: nightly

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -33,7 +33,7 @@ jobs:
     name: Fuzz Akita targets
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions-rust-lang/setup-rust-toolchain@a0b538fa0b742a6aa35d6e2c169b4bd06d225a98 # v1
         with:
           toolchain: nightly

--- a/.github/workflows/jolt-verifier-profile-smoke.yml
+++ b/.github/workflows/jolt-verifier-profile-smoke.yml
@@ -40,7 +40,7 @@ jobs:
       run:
         working-directory: profile/akita-recursion
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions-rust-lang/setup-rust-toolchain@a0b538fa0b742a6aa35d6e2c169b4bd06d225a98 # v1
         with:
           toolchain: 1.95

--- a/.github/workflows/jolt-verifier-profile-smoke.yml
+++ b/.github/workflows/jolt-verifier-profile-smoke.yml
@@ -47,7 +47,7 @@ jobs:
           targets: riscv32imac-unknown-none-elf,riscv64imac-unknown-none-elf
           cache: false
       - name: Cache profile/akita-recursion build
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           workspaces: profile/akita-recursion
           # The recursion workspace depends on Akita crates outside its own

--- a/.github/workflows/jolt-verifier-profile-smoke.yml
+++ b/.github/workflows/jolt-verifier-profile-smoke.yml
@@ -40,7 +40,7 @@ jobs:
       run:
         working-directory: profile/akita-recursion
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
       - uses: actions-rust-lang/setup-rust-toolchain@a0b538fa0b742a6aa35d6e2c169b4bd06d225a98 # v1
         with:
           toolchain: 1.95

--- a/.github/workflows/portability.yml
+++ b/.github/workflows/portability.yml
@@ -22,7 +22,7 @@ jobs:
     name: Portable x86 verifier check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
       - uses: actions-rust-lang/setup-rust-toolchain@a0b538fa0b742a6aa35d6e2c169b4bd06d225a98 # v1
       - name: Check verifier with portable CPU target
         run: RUSTFLAGS="-D warnings -C target-cpu=x86-64" cargo check --release -p akita-verifier --no-default-features --features transcript-blake2b
@@ -35,7 +35,7 @@ jobs:
     name: Native AArch64 NEON exact NTT
     runs-on: ubuntu-24.04-arm
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
       - uses: actions-rust-lang/setup-rust-toolchain@a0b538fa0b742a6aa35d6e2c169b4bd06d225a98 # v1
       - name: Require native AArch64 NEON
         run: |
@@ -53,7 +53,7 @@ jobs:
     name: AVX-512 IFMA exact NTT (emulated)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
       - uses: actions-rust-lang/setup-rust-toolchain@a0b538fa0b742a6aa35d6e2c169b4bd06d225a98 # v1
       - name: Install Intel Software Development Emulator
         run: |
@@ -74,7 +74,7 @@ jobs:
     name: Wasm serialization check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
       - uses: actions-rust-lang/setup-rust-toolchain@a0b538fa0b742a6aa35d6e2c169b4bd06d225a98 # v1
       - name: Add wasm target
         run: rustup target add wasm32-unknown-unknown

--- a/.github/workflows/portability.yml
+++ b/.github/workflows/portability.yml
@@ -22,7 +22,7 @@ jobs:
     name: Portable x86 verifier check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions-rust-lang/setup-rust-toolchain@a0b538fa0b742a6aa35d6e2c169b4bd06d225a98 # v1
       - name: Check verifier with portable CPU target
         run: RUSTFLAGS="-D warnings -C target-cpu=x86-64" cargo check --release -p akita-verifier --no-default-features --features transcript-blake2b
@@ -35,7 +35,7 @@ jobs:
     name: Native AArch64 NEON exact NTT
     runs-on: ubuntu-24.04-arm
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions-rust-lang/setup-rust-toolchain@a0b538fa0b742a6aa35d6e2c169b4bd06d225a98 # v1
       - name: Require native AArch64 NEON
         run: |
@@ -53,7 +53,7 @@ jobs:
     name: AVX-512 IFMA exact NTT (emulated)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions-rust-lang/setup-rust-toolchain@a0b538fa0b742a6aa35d6e2c169b4bd06d225a98 # v1
       - name: Install Intel Software Development Emulator
         run: |
@@ -74,7 +74,7 @@ jobs:
     name: Wasm serialization check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions-rust-lang/setup-rust-toolchain@a0b538fa0b742a6aa35d6e2c169b4bd06d225a98 # v1
       - name: Add wasm target
         run: rustup target add wasm32-unknown-unknown

--- a/.github/workflows/profile-bench-comment.yml
+++ b/.github/workflows/profile-bench-comment.yml
@@ -43,7 +43,7 @@ jobs:
         # Only a total build failure leaves no artifact; the upsert step no-ops
         # on a missing file, so don't fail the job.
         continue-on-error: true
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ env.AKITA_BENCH_ARTIFACT_NAME }}
           path: ${{ runner.temp }}/profile-bench-artifact

--- a/.github/workflows/profile-bench-comment.yml
+++ b/.github/workflows/profile-bench-comment.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - name: Resolve PR number
         id: pr
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const prs = context.payload.workflow_run.pull_requests || [];
@@ -53,7 +53,7 @@ jobs:
 
       - name: Upsert benchmark PR comment
         if: steps.pr.outputs.issue-number != ''
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           AKITA_BENCH_COMMENT: ${{ runner.temp }}/profile-bench-artifact/comment.md
           AKITA_BENCH_ISSUE_NUMBER: ${{ steps.pr.outputs.issue-number }}

--- a/.github/workflows/profile-bench.yml
+++ b/.github/workflows/profile-bench.yml
@@ -100,7 +100,7 @@ jobs:
               onehot_fp128_multi_chunk_w4r2:32:1
               onehot_fp128_multi_chunk_w8r2:32:1
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
@@ -324,7 +324,7 @@ jobs:
     if: ${{ always() && !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 

--- a/.github/workflows/profile-bench.yml
+++ b/.github/workflows/profile-bench.yml
@@ -126,7 +126,7 @@ jobs:
 
       - name: Determine PR benchmark merge base
         if: github.event_name == 'pull_request'
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const { execFileSync } = require('child_process');
@@ -348,7 +348,7 @@ jobs:
 
       - name: Determine PR benchmark merge base
         if: github.event_name == 'pull_request'
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const { execFileSync } = require('child_process');
@@ -387,7 +387,7 @@ jobs:
       - name: Determine previous benchmark run for this PR
         if: github.event_name == 'pull_request'
         id: bench-baselines
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const { owner, repo } = context.repo;
@@ -541,7 +541,7 @@ jobs:
         if: >-
           github.event_name == 'pull_request' &&
           github.event.pull_request.head.repo.full_name == github.repository
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/profile-bench.yml
+++ b/.github/workflows/profile-bench.yml
@@ -307,7 +307,7 @@ jobs:
       # for passing ones, so `report` can still render a comparison.
       - name: Upload per-group benchmark artifact
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ env.AKITA_BENCH_ARTIFACT_NAME }}-${{ matrix.group.name }}
           path: ${{ env.AKITA_BENCH_GROUP_DIR }}
@@ -590,7 +590,7 @@ jobs:
 
       - name: Upload benchmark artifact
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ env.AKITA_BENCH_ARTIFACT_NAME }}
           path: ${{ env.AKITA_BENCH_ARTIFACT_DIR }}

--- a/.github/workflows/profile-bench.yml
+++ b/.github/workflows/profile-bench.yml
@@ -100,7 +100,7 @@ jobs:
               onehot_fp128_multi_chunk_w4r2:32:1
               onehot_fp128_multi_chunk_w8r2:32:1
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
         with:
           fetch-depth: 0
 
@@ -324,7 +324,7 @@ jobs:
     if: ${{ always() && !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/profile-bench.yml
+++ b/.github/workflows/profile-bench.yml
@@ -461,7 +461,7 @@ jobs:
 
       - name: Download previous PR run artifact
         if: github.event_name == 'pull_request' && steps.bench-baselines.outputs.previous-run-id != ''
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ env.AKITA_BENCH_ARTIFACT_NAME }}
           path: ${{ env.AKITA_BENCH_PREVIOUS_RUN_DIR }}
@@ -469,7 +469,7 @@ jobs:
           github-token: ${{ github.token }}
 
       - name: Download per-group benchmark artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: ${{ env.AKITA_BENCH_ARTIFACT_NAME }}-*
           path: ${{ env.AKITA_BENCH_PARTS_DIR }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -23,7 +23,7 @@ jobs:
     name: Cargo deny
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions-rust-lang/setup-rust-toolchain@a0b538fa0b742a6aa35d6e2c169b4bd06d225a98 # v1
       - uses: EmbarkStudios/cargo-deny-action@08f29ebbc9295095546acaf37220058f628a4720 # v2
         with:
@@ -33,7 +33,7 @@ jobs:
     name: Cargo audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions-rust-lang/setup-rust-toolchain@a0b538fa0b742a6aa35d6e2c169b4bd06d225a98 # v1
       - name: Install cargo-audit
         uses: taiki-e/install-action@50414676f9f5d50a65992c6dd2ed02641263226c # cargo-audit

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -23,7 +23,7 @@ jobs:
     name: Cargo deny
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
       - uses: actions-rust-lang/setup-rust-toolchain@a0b538fa0b742a6aa35d6e2c169b4bd06d225a98 # v1
       - uses: EmbarkStudios/cargo-deny-action@08f29ebbc9295095546acaf37220058f628a4720 # v2
         with:
@@ -33,7 +33,7 @@ jobs:
     name: Cargo audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
       - uses: actions-rust-lang/setup-rust-toolchain@a0b538fa0b742a6aa35d6e2c169b4bd06d225a98 # v1
       - name: Install cargo-audit
         uses: taiki-e/install-action@50414676f9f5d50a65992c6dd2ed02641263226c # cargo-audit

--- a/.github/workflows/test-timing-comment.yml
+++ b/.github/workflows/test-timing-comment.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Checkout trusted default branch
         if: steps.pr.outputs.issue-number != ''
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
         with:
           ref: ${{ github.event.repository.default_branch }}
 

--- a/.github/workflows/test-timing-comment.yml
+++ b/.github/workflows/test-timing-comment.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Download current test timing artifact
         if: steps.pr.outputs.issue-number != ''
         continue-on-error: true
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ env.AKITA_TEST_TIMING_ARTIFACT_NAME }}
           path: ${{ runner.temp }}/ci-test-timing-current
@@ -141,7 +141,7 @@ jobs:
 
       - name: Download main baseline artifact
         if: steps.baselines.outputs.main-run-id != ''
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ env.AKITA_TEST_TIMING_ARTIFACT_NAME }}
           path: ${{ runner.temp }}/ci-test-timing-main-baseline
@@ -150,7 +150,7 @@ jobs:
 
       - name: Download previous run artifact
         if: steps.baselines.outputs.previous-run-id != ''
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ env.AKITA_TEST_TIMING_ARTIFACT_NAME }}
           path: ${{ runner.temp }}/ci-test-timing-previous-run

--- a/.github/workflows/test-timing-comment.yml
+++ b/.github/workflows/test-timing-comment.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - name: Resolve PR number
         id: pr
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const prs = context.payload.workflow_run.pull_requests || [];
@@ -57,7 +57,7 @@ jobs:
       - name: Determine baseline artifacts
         if: steps.pr.outputs.issue-number != ''
         id: baselines
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const { owner, repo } = context.repo;
@@ -181,7 +181,7 @@ jobs:
 
       - name: Upsert timing PR comment
         if: steps.pr.outputs.issue-number != ''
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           AKITA_TEST_TIMING_COMMENT: ${{ runner.temp }}/ci-test-timing-current/comment.md
           AKITA_TEST_TIMING_ISSUE_NUMBER: ${{ steps.pr.outputs.issue-number }}

--- a/.github/workflows/test-timing-comment.yml
+++ b/.github/workflows/test-timing-comment.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Checkout trusted default branch
         if: steps.pr.outputs.issue-number != ''
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.repository.default_branch }}
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,13 +4,13 @@ version = 4
 
 [[package]]
 name = "aes"
-version = "0.8.4"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+checksum = "35f0f96ce78e38c3dc6d8948aa8163d06385be74000f3c7a95bf1eef35d3ea32"
 dependencies = [
- "cfg-if",
  "cipher",
- "cpufeatures 0.2.17",
+ "cpubits",
+ "cpufeatures 0.3.1",
 ]
 
 [[package]]
@@ -58,7 +58,7 @@ dependencies = [
  "jolt-field",
  "keccak 0.1.6",
  "serde",
- "sha3 0.10.9",
+ "sha3",
  "smallvec",
  "tracing",
 ]
@@ -105,10 +105,10 @@ dependencies = [
  "criterion",
  "jolt-field",
  "libc",
- "num-bigint",
+ "num-bigint 0.4.8",
  "p3-baby-bear",
- "p3-field",
- "p3-koala-bear",
+ "p3-field 0.7.0",
+ "p3-koala-bear 0.7.0",
  "p3-mersenne-31",
  "proptest",
  "rand 0.8.8",
@@ -153,7 +153,7 @@ dependencies = [
  "rand 0.8.8",
  "rand_core 0.6.4",
  "rayon",
- "sha3 0.10.9",
+ "sha3",
  "tracing",
 ]
 
@@ -199,11 +199,11 @@ dependencies = [
  "akita-types",
  "criterion",
  "libm",
- "num-bigint",
+ "num-bigint 0.4.8",
  "num-traits",
  "rayon",
  "sha2",
- "sha3 0.10.9",
+ "sha3",
  "thiserror",
 ]
 
@@ -248,7 +248,7 @@ dependencies = [
  "rand_core 0.6.4",
  "rayon",
  "serde",
- "sha3 0.10.9",
+ "sha3",
  "tracing",
 ]
 
@@ -320,7 +320,7 @@ dependencies = [
  "fnv",
  "hashbrown",
  "itertools 0.14.0",
- "num-bigint",
+ "num-bigint 0.4.8",
  "num-integer",
  "num-traits",
  "zeroize",
@@ -337,7 +337,7 @@ dependencies = [
  "ark-std",
  "digest 0.10.7",
  "educe",
- "num-bigint",
+ "num-bigint 0.4.8",
  "num-traits",
  "zeroize",
 ]
@@ -356,7 +356,7 @@ name = "ark-ff-macros"
 version = "0.6.0"
 source = "git+https://github.com/arkworks-rs/algebra?rev=3b2a12492cfeb34774a2cdbe9d8d7a869c883fa9#3b2a12492cfeb34774a2cdbe9d8d7a869c883fa9"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.8",
  "num-traits",
  "proc-macro2",
  "quote",
@@ -385,7 +385,7 @@ dependencies = [
  "ark-serialize-derive",
  "ark-std",
  "digest 0.10.7",
- "num-bigint",
+ "num-bigint 0.4.8",
 ]
 
 [[package]]
@@ -528,11 +528,12 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.4.4"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
 dependencies = [
- "crypto-common 0.1.7",
+ "block-buffer 0.12.1",
+ "crypto-common 0.2.2",
  "inout",
 ]
 
@@ -572,6 +573,12 @@ name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
 
 [[package]]
 name = "cpufeatures"
@@ -679,9 +686,9 @@ dependencies = [
 
 [[package]]
 name = "ctr"
-version = "0.9.2"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+checksum = "baaca1c4b237092596f64d571e9db6ce4109c4ef9742e27590f1709594461f21"
 dependencies = [
  "cipher",
 ]
@@ -889,11 +896,11 @@ dependencies = [
 
 [[package]]
 name = "inout"
-version = "0.1.4"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -921,6 +928,15 @@ name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
 dependencies = [
  "either",
 ]
@@ -1057,6 +1073,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93e7820bc0a80a0238e650327316f929ba18d5be054b647490a3a6a339f3e7c0"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1107,17 +1133,16 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "p3-baby-bear"
-version = "0.5.3"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bc665d4650710aedd2424a59d88c19cb94d85375defc87bf6264d4be25ae6fa"
+checksum = "40694b3680bbb9a76a6a3a3a467c0bd40b5791a96cb1cbad93a0a6a1f47a9a31"
 dependencies = [
- "p3-challenger",
- "p3-field",
- "p3-mds",
- "p3-monty-31",
- "p3-poseidon1",
- "p3-poseidon2",
- "p3-symmetric",
+ "p3-field 0.7.0",
+ "p3-mds 0.7.0",
+ "p3-monty-31 0.7.0",
+ "p3-poseidon1 0.7.0",
+ "p3-poseidon2 0.7.0",
+ "p3-symmetric 0.7.0",
  "rand 0.10.2",
 ]
 
@@ -1127,11 +1152,11 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8972ccd1d5dc90e46cdb1f2ab4ee2bae49b3917e5e98aa533f0c2b779c010445"
 dependencies = [
- "p3-field",
- "p3-maybe-rayon",
- "p3-monty-31",
- "p3-symmetric",
- "p3-util",
+ "p3-field 0.5.3",
+ "p3-maybe-rayon 0.5.4",
+ "p3-monty-31 0.5.3",
+ "p3-symmetric 0.5.3",
+ "p3-util 0.5.4",
  "tracing",
 ]
 
@@ -1142,11 +1167,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17771aca44632f9cc11f2718d7ea7ec06794946c4190ef3a985bfc893f14c18a"
 dependencies = [
  "itertools 0.14.0",
- "p3-field",
- "p3-matrix",
- "p3-maybe-rayon",
- "p3-util",
- "spin",
+ "p3-field 0.5.3",
+ "p3-matrix 0.5.3",
+ "p3-maybe-rayon 0.5.4",
+ "p3-util 0.5.4",
+ "spin 0.10.1",
+ "tracing",
+]
+
+[[package]]
+name = "p3-dft"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4344492a3a2981879411ef31b51b12fb364efeda59b9ac855d7d92559e7b46e8"
+dependencies = [
+ "itertools 0.15.0",
+ "p3-field 0.7.0",
+ "p3-matrix 0.7.0",
+ "p3-maybe-rayon 0.7.0",
+ "p3-util 0.7.0",
+ "spin 0.12.3",
  "tracing",
 ]
 
@@ -1157,9 +1197,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f3eb24d0591fd4d282d89cbe4e4efba5571c699375006f80b2cbf53ce83461c"
 dependencies = [
  "itertools 0.14.0",
- "num-bigint",
- "p3-maybe-rayon",
- "p3-util",
+ "num-bigint 0.4.8",
+ "p3-maybe-rayon 0.5.4",
+ "p3-util 0.5.4",
+ "paste",
+ "rand 0.10.2",
+ "serde",
+ "tracing",
+]
+
+[[package]]
+name = "p3-field"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f45f7364ae3aac1bd42e8dfec4aa76d1bc9087c4749649c893a671e386e96727"
+dependencies = [
+ "itertools 0.15.0",
+ "num-bigint 0.5.1",
+ "p3-maybe-rayon 0.7.0",
+ "p3-util 0.7.0",
  "paste",
  "rand 0.10.2",
  "serde",
@@ -1173,12 +1229,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61e31d7adaecf270811e3f4b52dc12214235a5427b976a49a45f73d542fc0a2d"
 dependencies = [
  "p3-challenger",
- "p3-field",
- "p3-mds",
- "p3-monty-31",
- "p3-poseidon1",
- "p3-poseidon2",
- "p3-symmetric",
+ "p3-field 0.5.3",
+ "p3-mds 0.5.3",
+ "p3-monty-31 0.5.3",
+ "p3-poseidon1 0.5.3",
+ "p3-poseidon2 0.5.3",
+ "p3-symmetric 0.5.3",
+ "rand 0.10.2",
+]
+
+[[package]]
+name = "p3-koala-bear"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b063a966b091fca89c1f879e0a5e21b7f5013cf9e361e98297c07d58ed7ebe6d"
+dependencies = [
+ "p3-field 0.7.0",
+ "p3-mds 0.7.0",
+ "p3-monty-31 0.7.0",
+ "p3-poseidon1 0.7.0",
+ "p3-poseidon2 0.7.0",
+ "p3-symmetric 0.7.0",
  "rand 0.10.2",
 ]
 
@@ -1189,9 +1260,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea9c94c0714944e7b8a9a62e6340b1e3e1d3f8ecfd3e35c08798360200e73eff"
 dependencies = [
  "itertools 0.14.0",
- "p3-field",
- "p3-maybe-rayon",
- "p3-util",
+ "p3-field 0.5.3",
+ "p3-maybe-rayon 0.5.4",
+ "p3-util 0.5.4",
+ "rand 0.10.2",
+ "serde",
+ "tracing",
+]
+
+[[package]]
+name = "p3-matrix"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92f322bd7dded657d51f4c3adcc64bed27ffe4894dbd0f9c077d5670ce73217e"
+dependencies = [
+ "itertools 0.15.0",
+ "p3-field 0.7.0",
+ "p3-maybe-rayon 0.7.0",
+ "p3-util 0.7.0",
  "rand 0.10.2",
  "serde",
  "tracing",
@@ -1204,34 +1290,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d1ffb2d24a932d4fa5258f3288130973175f1982c7606f9f7df5270c895531c"
 
 [[package]]
+name = "p3-maybe-rayon"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "486d6396b0d22274f862a6c5987bb25f9ea61b34f21b54c23a2ee53f2d8c20ea"
+
+[[package]]
 name = "p3-mds"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b5441fa8116246ec9e6c835f15273cb27777ca572960ec87476b67fef13e01e"
 dependencies = [
- "p3-dft",
- "p3-field",
- "p3-symmetric",
- "p3-util",
+ "p3-dft 0.5.3",
+ "p3-field 0.5.3",
+ "p3-symmetric 0.5.3",
+ "p3-util 0.5.4",
+ "rand 0.10.2",
+]
+
+[[package]]
+name = "p3-mds"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00e11f572a44aa3c91057e59625d0992aacc6ffdb80dc1b44948d5587d66a159"
+dependencies = [
+ "p3-dft 0.7.0",
+ "p3-field 0.7.0",
+ "p3-symmetric 0.7.0",
+ "p3-util 0.7.0",
  "rand 0.10.2",
 ]
 
 [[package]]
 name = "p3-mersenne-31"
-version = "0.5.3"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "012351fb727ba404175ea1cc159fb6234fa370ce9399317ba04d38ca43e55bfa"
+checksum = "b9fffe308287d1644c518a8c7f161581baabb2590783d3c686313f44e487e72b"
 dependencies = [
- "itertools 0.14.0",
- "num-bigint",
- "p3-challenger",
- "p3-dft",
- "p3-field",
- "p3-matrix",
- "p3-mds",
- "p3-poseidon2",
- "p3-symmetric",
- "p3-util",
+ "itertools 0.15.0",
+ "num-bigint 0.5.1",
+ "p3-dft 0.7.0",
+ "p3-field 0.7.0",
+ "p3-matrix 0.7.0",
+ "p3-mds 0.7.0",
+ "p3-poseidon1 0.7.0",
+ "p3-poseidon2 0.7.0",
+ "p3-symmetric 0.7.0",
+ "p3-util 0.7.0",
  "paste",
  "rand 0.10.2",
  "serde",
@@ -1244,20 +1349,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8724f330ea6d19dd4f2436aa0f88b5fcbf88f0f55ca7fccd3fea8b736dbcddad"
 dependencies = [
  "itertools 0.14.0",
- "num-bigint",
- "p3-dft",
- "p3-field",
- "p3-matrix",
- "p3-maybe-rayon",
- "p3-mds",
- "p3-poseidon1",
- "p3-poseidon2",
- "p3-symmetric",
- "p3-util",
+ "num-bigint 0.4.8",
+ "p3-dft 0.5.3",
+ "p3-field 0.5.3",
+ "p3-matrix 0.5.3",
+ "p3-maybe-rayon 0.5.4",
+ "p3-mds 0.5.3",
+ "p3-poseidon1 0.5.3",
+ "p3-poseidon2 0.5.3",
+ "p3-symmetric 0.5.3",
+ "p3-util 0.5.4",
  "paste",
  "rand 0.10.2",
  "serde",
- "spin",
+ "spin 0.10.1",
+ "tracing",
+]
+
+[[package]]
+name = "p3-monty-31"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d189ef589fa016c579d46714cbe3329dc39bf4f991a6164f12fa6bf8f6ef217a"
+dependencies = [
+ "itertools 0.15.0",
+ "num-bigint 0.5.1",
+ "p3-dft 0.7.0",
+ "p3-field 0.7.0",
+ "p3-matrix 0.7.0",
+ "p3-maybe-rayon 0.7.0",
+ "p3-mds 0.7.0",
+ "p3-poseidon1 0.7.0",
+ "p3-poseidon2 0.7.0",
+ "p3-symmetric 0.7.0",
+ "p3-util 0.7.0",
+ "paste",
+ "rand 0.10.2",
+ "serde",
+ "spin 0.12.3",
  "tracing",
 ]
 
@@ -1267,8 +1396,20 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04e2a562fea210baae390a32f9ecf0dd8724ae3f4352d1c8e413077b6f00a162"
 dependencies = [
- "p3-field",
- "p3-symmetric",
+ "p3-field 0.5.3",
+ "p3-symmetric 0.5.3",
+ "rand 0.10.2",
+]
+
+[[package]]
+name = "p3-poseidon1"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "457e895bcf89b77e062653021b60c12ccd94dce599c54898d9ced4bfbabc820d"
+dependencies = [
+ "p3-field 0.7.0",
+ "p3-mds 0.7.0",
+ "p3-symmetric 0.7.0",
  "rand 0.10.2",
 ]
 
@@ -1278,10 +1419,23 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06394851c161d17e4aa4ad2aad5557d32f14cadd1dc838f965d8e1821a63b8c5"
 dependencies = [
- "p3-field",
- "p3-mds",
- "p3-symmetric",
- "p3-util",
+ "p3-field 0.5.3",
+ "p3-mds 0.5.3",
+ "p3-symmetric 0.5.3",
+ "p3-util 0.5.4",
+ "rand 0.10.2",
+]
+
+[[package]]
+name = "p3-poseidon2"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65501f32d58b5055c9470ccff459b2576de5f4e6ba72e91f78457231bc67b1c6"
+dependencies = [
+ "p3-field 0.7.0",
+ "p3-mds 0.7.0",
+ "p3-symmetric 0.7.0",
+ "p3-util 0.7.0",
  "rand 0.10.2",
 ]
 
@@ -1292,8 +1446,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ac1a276d421f8ef3361bb7d8c39a02c93c6b3f10eeaa559cc4c50222f9a5b82"
 dependencies = [
  "itertools 0.14.0",
- "p3-field",
- "p3-util",
+ "p3-field 0.5.3",
+ "p3-util 0.5.4",
+ "serde",
+]
+
+[[package]]
+name = "p3-symmetric"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3335886a1e2bec45877e050f76e6bf7a1a77019111c5f599d8b41c5889a2ea1c"
+dependencies = [
+ "itertools 0.15.0",
+ "p3-field 0.7.0",
+ "p3-util 0.7.0",
  "serde",
 ]
 
@@ -1305,6 +1471,16 @@ checksum = "d67ad92cd9397a7377acd7116d0920b603ba7bec9a3528ab56fe1224586f44c6"
 dependencies = [
  "serde",
  "transpose",
+]
+
+[[package]]
+name = "p3-util"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e020b468e9188da32310d8c876225e5183df105a1970368df97f8a76b85dcc5b"
+dependencies = [
+ "p3-maybe-rayon 0.7.0",
+ "serde",
 ]
 
 [[package]]
@@ -1645,16 +1821,6 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.10.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
-dependencies = [
- "digest 0.10.7",
- "keccak 0.1.6",
-]
-
-[[package]]
-name = "sha3"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
@@ -1700,6 +1866,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0134f9043ed38b087ac4f7d4af44c79e2c9e5094421fe3164f435ce585953b10"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "spongefish"
 version = "0.7.0"
 source = "git+https://github.com/arkworks-rs/spongefish?rev=d2d190b1329d35ac9577438d05aed4f17a57b9f9#d2d190b1329d35ac9577438d05aed4f17a57b9f9"
@@ -1707,10 +1882,10 @@ dependencies = [
  "blake2 0.11.0",
  "digest 0.11.3",
  "keccak 0.1.6",
- "p3-koala-bear",
+ "p3-koala-bear 0.5.3",
  "rand 0.8.8",
  "sha2",
- "sha3 0.11.0",
+ "sha3",
 ]
 
 [[package]]

--- a/crates/akita-challenges/Cargo.toml
+++ b/crates/akita-challenges/Cargo.toml
@@ -22,7 +22,7 @@ tracing = "0.1"
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }
-sha3 = "0.10.8"
+sha3 = "0.11.0"
 
 [[bench]]
 name = "sparse_challenge"

--- a/crates/akita-pcs/Cargo.toml
+++ b/crates/akita-pcs/Cargo.toml
@@ -128,10 +128,10 @@ ark-bn254 = { git = "https://github.com/arkworks-rs/algebra", rev = "3b2a12492cf
   "scalar_field",
 ] }
 ark-ff = { git = "https://github.com/arkworks-rs/algebra", rev = "3b2a12492cfeb34774a2cdbe9d8d7a869c883fa9" }
-p3-field = "=0.5.3"
-p3-mersenne-31 = "=0.5.3"
-p3-baby-bear = "=0.5.3"
-p3-koala-bear = "=0.5.3"
+p3-field = "=0.7.0"
+p3-mersenne-31 = "=0.7.0"
+p3-baby-bear = "=0.7.0"
+p3-koala-bear = "=0.7.0"
 tracing-chrome = "0.7"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "registry"] }
 serde_json = "1"

--- a/crates/akita-prover/Cargo.toml
+++ b/crates/akita-prover/Cargo.toml
@@ -21,11 +21,11 @@ akita-serialization = { version = "0.1.0", path = "../akita-serialization" }
 akita-sumcheck = { version = "0.1.0", path = "../akita-sumcheck", default-features = false }
 akita-transcript = { version = "0.1.0", path = "../akita-transcript", default-features = false }
 akita-types = { version = "0.1.0", path = "../akita-types", default-features = false }
-aes = "0.8.4"
-ctr = "0.9.2"
+aes = "0.9.3"
+ctr = "0.10.1"
 rand_core = "0.6"
 rayon = { version = "1.10", optional = true }
-sha3 = "0.10.8"
+sha3 = "0.11.0"
 tracing = "0.1"
 
 [dev-dependencies]

--- a/crates/akita-sis-estimator/Cargo.toml
+++ b/crates/akita-sis-estimator/Cargo.toml
@@ -15,7 +15,7 @@ num-bigint = "0.4.6"
 num-traits = "0.2"
 rayon = { version = "1.10", optional = true }
 sha2 = "0.11"
-sha3 = "0.10.8"
+sha3 = "0.11.0"
 thiserror = "2.0"
 
 [dev-dependencies]

--- a/crates/akita-types/Cargo.toml
+++ b/crates/akita-types/Cargo.toml
@@ -24,7 +24,7 @@ rayon = { version = "1.10", optional = true }
 blake2 = "0.10.6"
 num-traits = "0.2"
 rand_core = "0.6"
-sha3 = "0.10.8"
+sha3 = "0.11.0"
 tracing = "0.1"
 
 [features]

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -89,7 +89,7 @@ dependencies = [
  "num-traits",
  "rand_core 0.6.4",
  "serde",
- "sha3 0.10.9",
+ "sha3",
  "tracing",
 ]
 
@@ -706,16 +706,6 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.10.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
-dependencies = [
- "digest 0.10.7",
- "keccak 0.1.6",
-]
-
-[[package]]
-name = "sha3"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
@@ -755,7 +745,7 @@ dependencies = [
  "p3-koala-bear",
  "rand 0.8.8",
  "sha2",
- "sha3 0.11.0",
+ "sha3",
 ]
 
 [[package]]

--- a/profile/akita-recursion/Cargo.lock
+++ b/profile/akita-recursion/Cargo.lock
@@ -26,13 +26,13 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aes"
-version = "0.8.4"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+checksum = "35f0f96ce78e38c3dc6d8948aa8163d06385be74000f3c7a95bf1eef35d3ea32"
 dependencies = [
- "cfg-if",
  "cipher",
- "cpufeatures 0.2.17",
+ "cpubits",
+ "cpufeatures 0.3.1",
 ]
 
 [[package]]
@@ -138,7 +138,7 @@ dependencies = [
  "jolt-field",
  "rand_core 0.6.4",
  "rayon",
- "sha3 0.10.9",
+ "sha3 0.11.0",
  "tracing",
 ]
 
@@ -280,7 +280,7 @@ dependencies = [
  "rand_core 0.6.4",
  "rayon",
  "serde",
- "sha3 0.10.9",
+ "sha3 0.11.0",
  "tracing",
 ]
 
@@ -702,11 +702,12 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.4.4"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
 dependencies = [
- "crypto-common 0.1.7",
+ "block-buffer 0.12.1",
+ "crypto-common 0.2.2",
  "inout",
 ]
 
@@ -804,6 +805,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -892,9 +899,9 @@ dependencies = [
 
 [[package]]
 name = "ctr"
-version = "0.9.2"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+checksum = "baaca1c4b237092596f64d571e9db6ce4109c4ef9742e27590f1709594461f21"
 dependencies = [
  "cipher",
 ]
@@ -1250,11 +1257,11 @@ dependencies = [
 
 [[package]]
 name = "inout"
-version = "0.1.4"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -2482,16 +2489,6 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.3.1",
  "digest 0.11.3",
-]
-
-[[package]]
-name = "sha3"
-version = "0.10.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
-dependencies = [
- "digest 0.10.7",
- "keccak 0.1.6",
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- consolidate the ten open Dependabot updates from #1 through #10 into one reviewed dependency change
- update actions/github-script to 9.0.0, actions/upload-artifact to 7.0.1, actions/download-artifact to 8.0.1, Swatinem/rust-cache to 2.9.2, and actions/checkout to 7.0.1, all pinned by full commit SHA
- update ctr to 0.10.1, sha3 to 0.11.0, and the direct Plonky3 dev dependency family to 0.7.0
- update aes to 0.9.3 and p3-koala-bear to 0.7.0 so the related major-version families remain API-compatible
- refresh the root, fuzz, and recursion-profile lockfiles
- configure Dependabot multi-ecosystem grouping so weekly Cargo and GitHub Actions updates arrive in one PR going forward

## Compatibility findings

The isolated updates were not independently mergeable as generated. ctr 0.10.1 requires the cipher 0.5 traits implemented by aes 0.9, and mixing p3-field 0.7 with p3-koala-bear 0.5 caused duplicate-trait failures in akita-pcs benchmark targets. This PR updates each family atomically.

## Testing

- scripts/generate-schedule-artifacts.sh
- cargo fmt --all --check
- Taplo formatting checks for all changed Cargo manifests
- Rust file line-cap checks
- Python script test suite: 83 passed
- dependency hygiene checks for verifier, prover, config, planner, and setup
- scripts/check-shared-field-identity.sh
- scripts/check-external-schedule-artifacts.sh
- cargo machete --with-metadata
- scripts/check-doc-guardrails.sh
- changed-file typos check
- all three release Clippy feature graphs with -D warnings
- focused compatibility tests: 4 PRG, 41 challenge, 78 SIS estimator, and 605 type tests passed
- exact CI Nextest command, both shards: 877 and 876 tests passed

Supersedes #1, #2, #3, #4, #5, #6, #7, #8, #9, and #10.