### PR TITLE
fix(prover): reject invalid dense polynomial shapes

### DIFF
--- a/crates/akita-pcs/benches/coefficient_packing.rs
+++ b/crates/akita-pcs/benches/coefficient_packing.rs
@@ -61,7 +61,7 @@ fn bench_dense_shape<F, E, const D: usize>(
             }))
         })
         .collect();
-    let poly = DensePoly::from_ring_coeffs(rings);
+    let poly = DensePoly::from_ring_coeffs(rings).unwrap();
     let refs = [&poly];
     let batch = <DensePoly<F> as RootOpeningSource<F, D>>::opening_batch(&refs).unwrap();
     let plan = SubringCoefficientPackingPlan { point: &point };

--- a/crates/akita-prover/src/api/setup_prefix.rs
+++ b/crates/akita-prover/src/api/setup_prefix.rs
@@ -77,7 +77,7 @@ where
     }
 
     let ring_elems = extract_setup_prefix_ring_elems::<F, D>(expanded, full_prefix_ring_slots)?;
-    let dense = DensePoly::from_ring_coeffs::<D>(ring_elems);
+    let dense = DensePoly::from_ring_coeffs::<D>(ring_elems)?;
     let view = <DensePoly<F> as RootCommitSource<F, D>>::commit_view(&dense)?;
     let witnesses = backend.commit_inner_group(
         prepared,

--- a/crates/akita-prover/src/backend/coefficient_packing.rs
+++ b/crates/akita-prover/src/backend/coefficient_packing.rs
@@ -306,7 +306,7 @@ mod tests {
             point.packing_weights(),
         )
         .unwrap();
-        let poly = DensePoly::from_ring_coeffs(rings);
+        let poly = DensePoly::from_ring_coeffs(rings).unwrap();
         let polys = [&poly];
         let batch = <DensePoly<T> as RootOpeningSource<T, RING_D>>::opening_batch(&polys).unwrap();
         let got = CpuBackend::DEFAULT
@@ -342,7 +342,7 @@ mod tests {
             point.packing_weights(),
         )
         .unwrap();
-        let poly = DensePoly::from_ring_coeffs(rings);
+        let poly = DensePoly::from_ring_coeffs(rings).unwrap();
         let polys = [&poly];
         let batch = <DensePoly<F> as RootOpeningSource<F, D>>::opening_batch(&polys).unwrap();
         let got = CpuBackend::DEFAULT
@@ -402,7 +402,7 @@ mod tests {
             point.packing_weights(),
         )
         .unwrap();
-        let poly = DensePoly::from_ring_coeffs(rings);
+        let poly = DensePoly::from_ring_coeffs(rings).unwrap();
         let polys = [&poly];
         let batch = <DensePoly<F> as RootOpeningSource<F, D>>::opening_batch(&polys).unwrap();
         let got = CpuBackend::DEFAULT
@@ -500,7 +500,7 @@ mod tests {
                 }))
             })
             .collect::<Vec<_>>();
-        let dense = DensePoly::from_ring_coeffs(rings);
+        let dense = DensePoly::from_ring_coeffs(rings).unwrap();
         let onehot = OneHotPoly::<F>::new(256, hot.map(Some).to_vec()).unwrap();
         let dense_refs = [&dense];
         let onehot_refs = [&onehot];
@@ -543,7 +543,7 @@ mod tests {
             &public_point,
         )
         .expect("recursive-style live prefix point");
-        let dense = DensePoly::from_ring_coeffs::<D>(vec![CyclotomicRing::zero(); 8]);
+        let dense = DensePoly::from_ring_coeffs::<D>(vec![CyclotomicRing::zero(); 8]).unwrap();
         let onehot = OneHotPoly::<F>::new(
             D,
             vec![
@@ -608,7 +608,8 @@ mod tests {
                     ))
                 })
                 .collect(),
-        );
+        )
+        .unwrap();
         let onehot = OneHotPoly::<F>::new(LARGE_D, hot.map(Some).to_vec()).unwrap();
         let dense_refs = [&dense];
         let onehot_refs = [&onehot];
@@ -674,6 +675,7 @@ mod tests {
                         })
                         .collect(),
                 )
+                .unwrap()
             })
             .collect::<Vec<_>>();
         let onehot_refs = onehot.iter().collect::<Vec<_>>();
@@ -716,7 +718,7 @@ mod tests {
                 }))
             })
             .collect::<Vec<_>>();
-        let dense = DensePoly::from_ring_coeffs(rings);
+        let dense = DensePoly::from_ring_coeffs(rings).unwrap();
         let dense_refs = [&dense];
         let recursive_refs = [&recursive];
         let dense_batch =

--- a/crates/akita-prover/src/backend/dense/poly.rs
+++ b/crates/akita-prover/src/backend/dense/poly.rs
@@ -5,7 +5,7 @@ use crate::kernels::linear::try_centered_i8;
 use crate::validation::is_i8_log_basis;
 use akita_algebra::ring::cyclotomic::BalancedDecomposePow2Params;
 use akita_algebra::CyclotomicRing;
-use akita_error::AkitaError;
+use akita_error::{checked, AkitaError};
 use akita_types::{RingVec, SUPPORTED_COMMITMENT_RING_DIMS};
 use jolt_field::solinas::parallel::*;
 use jolt_field::{CanonicalEncoding, Field};
@@ -154,7 +154,8 @@ impl<F: Field + CanonicalEncoding> DensePoly<F> {
     ///
     /// # Errors
     ///
-    /// Returns an error if `evals.len() != 2^num_vars`.
+    /// Returns an error if `2^num_vars` does not fit `usize` or
+    /// `evals.len() != 2^num_vars`.
     pub fn from_field_evals<'a>(
         num_vars: usize,
         evals: impl Into<Cow<'a, [F]>>,
@@ -163,8 +164,7 @@ impl<F: Field + CanonicalEncoding> DensePoly<F> {
         F: 'a,
     {
         let evals = evals.into();
-        let expected_len = 1usize
-            .checked_shl(num_vars as u32)
+        let expected_len = checked::pow2(num_vars)
             .ok_or_else(|| AkitaError::InvalidInput(format!("2^{num_vars} does not fit usize")))?;
         if evals.len() != expected_len {
             return Err(AkitaError::InvalidSize {
@@ -213,14 +213,24 @@ impl<F: Field + CanonicalEncoding> DensePoly<F> {
 
     /// Flatten an existing vector of ring elements into dense storage.
     ///
-    /// # Panics
+    /// The total coefficient count must be a positive power of two. All
+    /// supplied coefficients belong to the live polynomial; storage padding
+    /// for larger ring views does not change its variable count.
     ///
-    /// Panics if `coeffs.len() * D` overflows `usize`.
-    pub fn from_ring_coeffs<const D: usize>(coeffs: Vec<CyclotomicRing<F, D>>) -> Self {
-        let total = coeffs
-            .len()
-            .checked_mul(D)
-            .expect("ring elems * D overflow");
+    /// # Errors
+    ///
+    /// Returns an error if `coeffs.len() * D` overflows `usize`, is zero, or
+    /// is not a power of two.
+    pub fn from_ring_coeffs<const D: usize>(
+        coeffs: Vec<CyclotomicRing<F, D>>,
+    ) -> Result<Self, AkitaError> {
+        let total = checked::product([coeffs.len(), D])
+            .ok_or_else(|| AkitaError::InvalidInput("ring elems * D overflow".to_string()))?;
+        if !total.is_power_of_two() {
+            return Err(AkitaError::InvalidInput(format!(
+                "dense coefficient count {total} must be a positive power of two"
+            )));
+        }
         let physical_len = total.max(MIN_FLAT_COEFF_LEN);
 
         let small_i8_coeffs = try_small_i8_cache_from_ring_coeffs(&coeffs).map(|planes| {
@@ -237,12 +247,12 @@ impl<F: Field + CanonicalEncoding> DensePoly<F> {
         }
         flat.resize(physical_len, F::zero());
 
-        Self {
+        Ok(Self {
             num_vars: total.trailing_zeros() as usize,
             coeffs: RingVec::from_coeffs(flat),
             small_i8_coeffs,
             digit_cache: OnceLock::new(),
-        }
+        })
     }
 
     pub(super) fn digit_planes_for<const D: usize>(

--- a/crates/akita-prover/src/backend/dense/tests.rs
+++ b/crates/akita-prover/src/backend/dense/tests.rs
@@ -1,7 +1,9 @@
 use super::poly::DensePoly;
+use crate::compute::{RootCommitSource, RootPolyMeta};
 use akita_algebra::CyclotomicRing;
+use akita_error::AkitaError;
 use jolt_field::Prime128OffsetA7F7 as F;
-use jolt_field::{Ring, Zero};
+use jolt_field::{CanonicalEncoding, Ring, Zero};
 
 fn ring<const D: usize>(offset: u64) -> CyclotomicRing<F, D> {
     CyclotomicRing::from_coefficients(std::array::from_fn(|idx| {
@@ -13,7 +15,7 @@ fn ring<const D: usize>(offset: u64) -> CyclotomicRing<F, D> {
 fn ring_fold_matches_dense_multiplication_reference() {
     const D: usize = 8;
     let coeffs = (0..2).map(|idx| ring::<D>(10 * idx)).collect::<Vec<_>>();
-    let poly = DensePoly::<F>::from_ring_coeffs(coeffs.clone());
+    let poly = DensePoly::<F>::from_ring_coeffs(coeffs.clone()).unwrap();
     let scalars = vec![
         ring::<D>(100),
         ring::<D>(200),
@@ -64,4 +66,73 @@ fn dense_source_has_exact_views_across_supported_ring_dimensions() {
     assert_view::<256>(&poly, &evals);
     assert_view::<512>(&poly, &evals);
     assert_view::<1024>(&poly, &evals);
+}
+
+#[test]
+fn dense_ring_constructor_rejects_empty_and_irregular_sources() {
+    const D: usize = 512;
+    // 96 rings previously exposed only the first 32 of the supplied rings.
+    for num_rings in [0, 3, 96] {
+        let result =
+            DensePoly::<F>::from_ring_coeffs(vec![CyclotomicRing::<F, D>::zero(); num_rings]);
+        assert!(matches!(result, Err(AkitaError::InvalidInput(_))));
+    }
+    let zero_degree = DensePoly::<F>::from_ring_coeffs(vec![CyclotomicRing::<F, 0>::zero()]);
+    assert!(matches!(zero_degree, Err(AkitaError::InvalidInput(_))));
+    let odd_degree = DensePoly::<F>::from_ring_coeffs(vec![CyclotomicRing::<F, 3>::zero(); 2]);
+    assert!(matches!(odd_degree, Err(AkitaError::InvalidInput(_))));
+}
+
+#[test]
+fn dense_ring_constructor_preserves_the_entire_commitment_source_and_bound_scan() {
+    const D: usize = 512;
+    let modulus = (-F::from_u64(1)).to_u128_checked().unwrap() + 1;
+    // Exercise both small-i8 and full-field storage, including physical padding.
+    for num_rings in [1, 32, 64] {
+        for reach in [127u64, 128] {
+            let mut evals = (0..num_rings * D)
+                .map(|idx| F::from_u64((idx % 32) as u64))
+                .collect::<Vec<_>>();
+            evals[num_rings * D - 2] = -F::from_u64(reach);
+            evals[num_rings * D - 1] = F::from_u64(reach);
+            let rings = evals
+                .chunks_exact(D)
+                .map(|chunk| CyclotomicRing::<F, D>::from_coefficients(chunk.try_into().unwrap()))
+                .collect::<Vec<_>>();
+            let poly = DensePoly::<F>::from_ring_coeffs(rings.clone()).unwrap();
+
+            assert_eq!(1usize << RootPolyMeta::num_vars(&poly), evals.len());
+            assert_eq!(&poly.field_coeffs()[..evals.len()], evals);
+            assert_eq!(poly.ring_coeffs::<D>().unwrap(), rings);
+            <DensePoly<F> as RootCommitSource<F, D>>::commit_view(&poly).unwrap();
+            assert_eq!(
+                <DensePoly<F> as RootCommitSource<F, D>>::committed_centered_reach(
+                    &poly,
+                    modulus,
+                    modulus / 2,
+                )
+                .unwrap(),
+                (u128::from(reach), u128::from(reach)),
+            );
+            assert_eq!(
+                poly,
+                DensePoly::from_field_evals(RootPolyMeta::num_vars(&poly), evals).unwrap(),
+            );
+        }
+    }
+}
+
+#[test]
+fn dense_field_constructor_rejects_unrepresentable_arities() {
+    for num_vars in [usize::BITS as usize, usize::MAX] {
+        let result = DensePoly::<F>::from_field_evals(num_vars, vec![F::zero()]);
+        assert!(matches!(result, Err(AkitaError::InvalidInput(_))));
+    }
+}
+
+#[cfg(target_pointer_width = "64")]
+#[test]
+fn dense_field_constructor_rejects_arity_that_truncates_to_a_valid_shift() {
+    let result = DensePoly::<F>::from_field_evals((1usize << 32) + 14, vec![F::zero(); 1 << 14]);
+    assert!(matches!(result, Err(AkitaError::InvalidInput(_))));
 }

--- a/crates/akita-prover/src/backend/onehot/tests.rs
+++ b/crates/akita-prover/src/backend/onehot/tests.rs
@@ -24,7 +24,7 @@ where
         let coeff_idx = field_pos % D;
         coeffs[ring_idx].coeffs[coeff_idx] += F::one();
     }
-    DensePoly::from_ring_coeffs(coeffs)
+    DensePoly::from_ring_coeffs(coeffs).unwrap()
 }
 
 fn test_ring_scalar<F, const D: usize>(seed: u64) -> CyclotomicRing<F, D>

--- a/crates/akita-prover/src/backend/poly_helpers/tests.rs
+++ b/crates/akita-prover/src/backend/poly_helpers/tests.rs
@@ -161,7 +161,8 @@ fn compact_subfield_fold_matches_materialized_ring_oracle_for_all_sources() {
                 }))
             })
             .collect(),
-    );
+    )
+    .unwrap();
     assert_output(
         dense
             .evaluate_and_fold_subfield(subfield_multipliers, POSITIONS)

--- a/crates/akita-setup/src/lib.rs
+++ b/crates/akita-setup/src/lib.rs
@@ -1108,7 +1108,7 @@ mod tests {
                     .clone();
                 let num_coeffs = lp.blocks().live_blocks * lp.blocks().positions_per_block;
                 let coeffs = vec![CyclotomicRing::<TestF, TEST_D>::zero(); num_coeffs];
-                let poly = DensePoly::<TestF>::from_ring_coeffs(coeffs);
+                let poly = DensePoly::<TestF>::from_ring_coeffs(coeffs).unwrap();
 
                 let commit_u = |setup: &AkitaProverSetup<TestF>| {
                     let prepared = CpuBackend::DEFAULT.prepare_setup(setup).unwrap();


### PR DESCRIPTION
Reject empty and non-power-of-two dense ring inputs before deriving polynomial arity. Previously, 96 rings of dimension 512 retained 49,152 coefficients but exposed only 16,384 to commitment and source-bound checks.

`DensePoly::from_ring_coeffs` now returns `Result<Self, AkitaError>` and uses checked coefficient sizing. `from_field_evals` uses the canonical checked power-of-two primitive so oversized arities cannot truncate to a valid shift. Update the setup-prefix caller to propagate errors and adapt test and benchmark callers. Add regressions for the reported truncation and oversized-arity cases, plus preservation of the complete source and its bound scan.

Validation:
- All three Clippy configurations from `.github/workflows/ci.yml`, with `RUSTFLAGS=-D warnings`.
- `cargo fmt --all --check`, `taplo fmt --check`, Rust file line cap, dependency hygiene, shared-field identity, unused-dependency and spelling checks.
- Seven focused dense tests passed; the full test suite was not completed.
