### PR TITLE
fix(sumcheck): validate compressed round messages

### DIFF
--- a/book/src/foundations/multilinear-sumcheck.md
+++ b/book/src/foundations/multilinear-sumcheck.md
@@ -199,6 +199,23 @@ The types `UniPoly` and `CompressedUniPoly` in
 the verifier derives each expected coefficient count from the proof shape
 rather than trusting a length supplied by the proof.
 
+Every ordinary round message must retain at least its constant coefficient.
+The prover compresses the zero polynomial to `[0]`, including when its full
+coefficient vector is empty. An empty compressed message is malformed: the
+verifier cannot use it to reconstruct the linear coefficient from the incoming
+claim. Both ordinary sum-check drivers check the round count, nonempty messages,
+and degree bounds before absorbing any data in their own replay. A caller may
+already have absorbed the public statement or batching data before entering a
+driver.
+
+A single stored coefficient can still represent a linear polynomial, so its
+degree estimate is one. Ordinary rounds require a degree bound of at least one,
+even for constant polynomials. A zero-round proof instead has no messages and
+leaves the input claim for the final oracle check. These rules differ from
+[equality-factored sum-check](./eq-factored-sumcheck.md), where a valid constant
+inner polynomial has an empty message and its constant term is recovered from
+the normalized claim.
+
 ## Batching several claims
 
 Akita often needs several sum-checks at the same point in the protocol. Running

--- a/crates/akita-algebra/src/uni_poly.rs
+++ b/crates/akita-algebra/src/uni_poly.rs
@@ -180,19 +180,13 @@ pub struct CompressedUniPoly<E: Field> {
 }
 
 impl<E: Field> CompressedUniPoly<E> {
-    /// Degree of the underlying uncompressed polynomial.
+    /// Upper bound on the degree of the underlying uncompressed polynomial.
     ///
-    /// `compress()` stores `[c0, c2, ..., cd]` — exactly `d` entries for
-    /// degree `d >= 2`.  For `len <= 1` (degree 0 or 1, which are ambiguous
-    /// in compressed form) we report 0; this is conservative for the
-    /// verifier's degree-bound check since `degree_bound >= 2` in practice.
+    /// A single stored coefficient can represent a linear polynomial because
+    /// the omitted linear term depends on the sumcheck hint. Constant rounds
+    /// therefore also require a degree bound of at least one.
     pub fn degree(&self) -> usize {
-        let len = self.coeffs_except_linear_term.len();
-        if len <= 1 {
-            0
-        } else {
-            len
-        }
+        self.coeffs_except_linear_term.len()
     }
 
     fn recover_linear_term(&self, hint: &E) -> E {

--- a/crates/akita-algebra/src/uni_poly.rs
+++ b/crates/akita-algebra/src/uni_poly.rs
@@ -38,13 +38,15 @@ impl<E: Field> UniPoly<E> {
     ///
     /// The verifier can reconstruct/evaluate the missing linear coefficient using
     /// the per-round hint `g(0)+g(1)` from the sumcheck protocol.
+    /// An empty zero polynomial stores `[0]`, so every compressed round retains
+    /// a constant coefficient and can reconstruct its linear term from the hint.
     ///
     /// This matches the technique used by Jolt's sumcheck (`CompressedUniPoly`).
     pub fn compress(&self) -> CompressedUniPoly<E> {
         let coeffs = &self.coeffs;
         if coeffs.is_empty() {
             return CompressedUniPoly {
-                coeffs_except_linear_term: Vec::new(),
+                coeffs_except_linear_term: vec![E::zero()],
             };
         }
         if coeffs.len() == 1 {

--- a/crates/akita-pcs/tests/protocol_soundness.rs
+++ b/crates/akita-pcs/tests/protocol_soundness.rs
@@ -345,6 +345,48 @@ fn assert_invalid_proof<T: core::fmt::Debug>(
 }
 
 #[test]
+fn typed_verifier_rejects_empty_stage2_round_messages() {
+    init_rayon_pool();
+    let _guard = E2E_TEST_LOCK.lock().unwrap();
+    run_on_large_stack(|| {
+        type Cfg = fp128::Dense;
+        const LABEL: &[u8] = b"soundness/empty-stage2-round";
+        let scheme = load_workspace_scheme::<Cfg>().expect("workspace schedule catalog");
+        let (setup, commitment, proof, point, opening, _layout, selection) =
+            make_dense_fixture::<F, 256, Cfg>(&scheme, DENSE_TEST_NV, LABEL);
+        let statement = verify_input::<Cfg>(selection, &point, &[opening], &commitment);
+        scheme
+            .batched_verify(
+                &proof,
+                &setup,
+                &mut AkitaTranscript::<F>::new(LABEL),
+                statement,
+                BasisMode::Lagrange,
+            )
+            .expect("honest proof must verify");
+
+        let rounds = proof.root.stage2.sumcheck_proof.round_polys.len();
+        assert!(rounds > 1, "fixture must exercise a later round");
+        for round in [0, rounds - 1] {
+            let mut malformed = proof.clone();
+            malformed.root.stage2.sumcheck_proof.round_polys[round]
+                .coeffs_except_linear_term
+                .clear();
+            assert_invalid_proof(
+                "empty typed Stage 2 round",
+                scheme.batched_verify(
+                    &malformed,
+                    &setup,
+                    &mut AkitaTranscript::<F>::new(LABEL),
+                    verify_input::<Cfg>(selection, &point, &[opening], &commitment),
+                    BasisMode::Lagrange,
+                ),
+            );
+        }
+    });
+}
+
+#[test]
 fn trace_internalization_rejects_tampered_root_fold_handle() {
     init_rayon_pool();
     let _guard = E2E_TEST_LOCK.lock().unwrap();

--- a/crates/akita-sumcheck/src/batched_sumcheck.rs
+++ b/crates/akita-sumcheck/src/batched_sumcheck.rs
@@ -83,7 +83,8 @@ pub struct BatchedSumcheckRoundResult<E: Field> {
 ///
 /// # Errors
 ///
-/// Returns an error if the field inverse of 2 does not exist.
+/// Returns an error if no instances are supplied, or a nonzero-round batch has
+/// no positive degree bound for its compressed messages.
 #[tracing::instrument(skip_all, name = "prove_batched_sumcheck")]
 pub fn prove_batched_sumcheck<F, T, E, S>(
     mut instances: Vec<&mut (dyn SumcheckInstanceProver<E> + Send)>,
@@ -107,6 +108,12 @@ where
         .map(|inst| inst.num_rounds())
         .max()
         .unwrap(); // safe: non-empty checked above
+
+    if max_num_rounds != 0 && instances.iter().all(|inst| inst.degree_bound() == 0) {
+        return Err(AkitaError::InvalidInput(
+            "batched sumcheck rounds require a positive degree bound".into(),
+        ));
+    }
 
     // Absorb individual input claims.
     for inst in instances.iter() {

--- a/crates/akita-sumcheck/src/drivers/standard.rs
+++ b/crates/akita-sumcheck/src/drivers/standard.rs
@@ -126,12 +126,7 @@ where
         S: FnMut(&mut T) -> Result<E, AkitaError>,
     {
         let num_rounds = self.num_rounds();
-        if proof.round_polys.len() != num_rounds {
-            return Err(AkitaError::InvalidSize {
-                expected: num_rounds,
-                actual: proof.round_polys.len(),
-            });
-        }
+        proof.validate_round_messages(num_rounds, self.degree_bound())?;
 
         let mut claim = self.input_claim();
         tracing::debug!(
@@ -141,18 +136,9 @@ where
         );
         transcript.append_serde(labels::ABSORB_SUMCHECK_CLAIM, &claim);
 
-        let degree_bound = self.degree_bound();
         let mut challenges = Vec::with_capacity(num_rounds);
 
         for poly in &proof.round_polys {
-            if poly.degree() > degree_bound {
-                return Err(AkitaError::InvalidInput(format!(
-                    "sumcheck round poly degree {} exceeds bound {}",
-                    poly.degree(),
-                    degree_bound
-                )));
-            }
-
             transcript.append_serde(labels::ABSORB_SUMCHECK_ROUND, poly);
             let r_i = sample_challenge(transcript)?;
             challenges.push(r_i);

--- a/crates/akita-sumcheck/src/types.rs
+++ b/crates/akita-sumcheck/src/types.rs
@@ -226,23 +226,10 @@ impl<E: Field> SumcheckProof<E> {
         E: AkitaSerialize,
         S: FnMut(&mut T) -> Result<E, AkitaError>,
     {
-        if self.round_polys.len() != num_rounds {
-            return Err(AkitaError::InvalidSize {
-                expected: num_rounds,
-                actual: self.round_polys.len(),
-            });
-        }
+        self.validate_round_messages(num_rounds, degree_bound)?;
 
         let mut r = Vec::with_capacity(num_rounds);
         for poly in &self.round_polys {
-            if poly.degree() > degree_bound {
-                return Err(AkitaError::InvalidInput(format!(
-                    "sumcheck round poly degree {} exceeds bound {}",
-                    poly.degree(),
-                    degree_bound
-                )));
-            }
-
             transcript.append_serde(labels::ABSORB_SUMCHECK_ROUND, poly);
             let r_i = sample_challenge(transcript)?;
             r.push(r_i);
@@ -251,6 +238,50 @@ impl<E: Field> SumcheckProof<E> {
         }
 
         Ok((claim, r))
+    }
+
+    /// Reject a round-message vector that no honest prover can produce.
+    ///
+    /// Both transcript drivers call this before absorbing anything, so the two
+    /// loops cannot drift apart on what they accept.
+    ///
+    /// An **empty** compressed round message is the dangerous case. Its
+    /// `degree()` is zero, so it passes any degree bound, and
+    /// `CompressedUniPoly::eval_from_hint` evaluates it to zero without reading
+    /// the hint. Accepting one would let a proof reset the running claim to zero
+    /// and so decouple the incoming claim from every later round.
+    /// `UniPoly::compress` never produces it for a round message: a linear
+    /// polynomial already stores one coefficient.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AkitaError::InvalidSize`] if the round count is wrong,
+    /// [`AkitaError::InvalidProof`] for an empty round message, and
+    /// [`AkitaError::InvalidInput`] if a round exceeds `degree_bound`.
+    pub fn validate_round_messages(
+        &self,
+        num_rounds: usize,
+        degree_bound: usize,
+    ) -> Result<(), AkitaError> {
+        if self.round_polys.len() != num_rounds {
+            return Err(AkitaError::InvalidSize {
+                expected: num_rounds,
+                actual: self.round_polys.len(),
+            });
+        }
+        for poly in &self.round_polys {
+            if poly.coeffs_except_linear_term.is_empty() {
+                return Err(AkitaError::InvalidProof);
+            }
+            if poly.degree() > degree_bound {
+                return Err(AkitaError::InvalidInput(format!(
+                    "sumcheck round poly degree {} exceeds bound {}",
+                    poly.degree(),
+                    degree_bound
+                )));
+            }
+        }
+        Ok(())
     }
 }
 

--- a/crates/akita-sumcheck/src/types.rs
+++ b/crates/akita-sumcheck/src/types.rs
@@ -210,8 +210,9 @@ impl<E: Field> SumcheckProof<E> {
     ///
     /// # Errors
     ///
-    /// Returns an error if the proof length does not match `num_rounds` or if any
-    /// per-round polynomial exceeds `degree_bound`.
+    /// Returns an error if the proof length does not match `num_rounds`, a round
+    /// message is empty, or its degree estimate exceeds `degree_bound`. Nonempty
+    /// proofs require a degree bound of at least one, including constant rounds.
     pub fn verify<F, T, S>(
         &self,
         mut claim: E,
@@ -240,25 +241,10 @@ impl<E: Field> SumcheckProof<E> {
         Ok((claim, r))
     }
 
-    /// Reject a round-message vector that no honest prover can produce.
-    ///
-    /// Both transcript drivers call this before absorbing anything, so the two
-    /// loops cannot drift apart on what they accept.
-    ///
-    /// An **empty** compressed round message is the dangerous case. Its
-    /// `degree()` is zero, so it passes any degree bound, and
-    /// `CompressedUniPoly::eval_from_hint` evaluates it to zero without reading
-    /// the hint. Accepting one would let a proof reset the running claim to zero
-    /// and so decouple the incoming claim from every later round.
-    /// `UniPoly::compress` never produces it for a round message: a linear
-    /// polynomial already stores one coefficient.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`AkitaError::InvalidSize`] if the round count is wrong,
-    /// [`AkitaError::InvalidProof`] for an empty round message, and
-    /// [`AkitaError::InvalidInput`] if a round exceeds `degree_bound`.
-    pub fn validate_round_messages(
+    /// Validate both standard drivers' messages before transcript replay.
+    /// Empty messages must be rejected: their evaluator ignores the incoming
+    /// claim and returns zero instead of reconstructing the linear coefficient.
+    pub(crate) fn validate_round_messages(
         &self,
         num_rounds: usize,
         degree_bound: usize,

--- a/crates/akita-sumcheck/tests/drivers.rs
+++ b/crates/akita-sumcheck/tests/drivers.rs
@@ -4,11 +4,10 @@ use akita_algebra::split_eq::GruenSplitEq;
 use akita_error::AkitaError;
 use akita_serialization::{AkitaDeserialize, AkitaSerialize};
 use akita_sumcheck::{
-    advance_eq_factored_claim, CompressedUniPoly, EqFactoredSumcheckInstanceProver,
-    EqFactoredSumcheckInstanceProverExt, EqFactoredSumcheckInstanceVerifier,
-    EqFactoredSumcheckInstanceVerifierExt, EqFactoredUniPoly, SumcheckInstanceProver,
-    SumcheckInstanceProverExt, SumcheckInstanceVerifier, SumcheckInstanceVerifierExt,
-    SumcheckProof, UniPoly,
+    CompressedUniPoly, EqFactoredSumcheckInstanceProver, EqFactoredSumcheckInstanceProverExt,
+    EqFactoredSumcheckInstanceVerifier, EqFactoredSumcheckInstanceVerifierExt, EqFactoredUniPoly,
+    SumcheckInstanceProver, SumcheckInstanceProverExt, SumcheckInstanceVerifier,
+    SumcheckInstanceVerifierExt, SumcheckProof, UniPoly,
 };
 use akita_transcript::labels as tr_labels;
 use akita_transcript::{AkitaTranscript, Transcript};
@@ -189,27 +188,31 @@ fn eq_factored_round_wire_contains_every_nonconstant_coefficient() {
 
 #[test]
 fn eq_factored_degree_zero_round_has_an_empty_message() {
-    let q_coeffs = vec![F::from_u64(23)];
-    let mut prover = ToyEqFactoredInstance::new(F::from_u64(7), q_coeffs.clone());
-    let mut prover_transcript = new_transcript();
-    let (proof, _, final_claim) = prover
-        .prove::<F, _, _>(&mut prover_transcript, |_| Ok(F::from_u64(11)))
-        .unwrap();
+    // Empty eq-factored messages preserve the normalized claim, including at
+    // Boolean equality points and challenges, unlike empty ordinary messages.
+    for tau in [F::zero(), F::one(), F::from_u64(7)] {
+        for challenge in [F::zero(), F::one(), F::from_u64(11)] {
+            let q_coeffs = vec![F::from_u64(23)];
+            let mut prover = ToyEqFactoredInstance::new(tau, q_coeffs.clone());
+            let (proof, _, final_claim) = prover
+                .prove::<F, _, _>(&mut new_transcript(), |_| Ok(challenge))
+                .unwrap();
 
-    assert!(proof.round_polys[0].coeffs_except_constant_term.is_empty());
-    let mut encoded = Vec::new();
-    proof.round_polys[0]
-        .serialize_uncompressed(&mut encoded)
-        .unwrap();
-    assert!(encoded.is_empty());
-    assert_eq!(final_claim, q_coeffs[0]);
+            assert!(proof.round_polys[0].coeffs_except_constant_term.is_empty());
+            let mut encoded = Vec::new();
+            proof.round_polys[0]
+                .serialize_uncompressed(&mut encoded)
+                .unwrap();
+            assert!(encoded.is_empty());
+            assert_eq!(final_claim, q_coeffs[0]);
 
-    let verifier = ToyEqFactoredInstance::new(F::from_u64(7), q_coeffs);
-    let mut verifier_transcript = new_transcript();
-    assert_eq!(
-        verifier.verify::<F, _, _>(&proof, &mut verifier_transcript, |_| Ok(F::from_u64(11))),
-        Ok(vec![F::from_u64(11)])
-    );
+            let verifier = ToyEqFactoredInstance::new(tau, q_coeffs);
+            assert_eq!(
+                verifier.verify::<F, _, _>(&proof, &mut new_transcript(), |_| Ok(challenge)),
+                Ok(vec![challenge])
+            );
+        }
+    }
 }
 
 struct ToyTwoRoundEqFactoredInstance {
@@ -568,19 +571,4 @@ fn empty_zero_polynomial_round_trips_through_standard_and_batched_sumcheck() {
         ),
         Ok(challenges)
     );
-}
-
-/// The eq-factored driver is not vulnerable and so is not guarded: an empty
-/// `q` message leaves the normalized claim untouched rather than zeroing it,
-/// because both the `tau`-scaled correction and the evaluation are zero.
-#[test]
-fn eq_factored_empty_round_message_preserves_the_claim() {
-    let empty = EqFactoredUniPoly::<F> {
-        coeffs_except_constant_term: Vec::new(),
-    };
-    let claim = F::from_u64(7);
-
-    let advanced = advance_eq_factored_claim(claim, F::from_u64(2), &empty, F::from_u64(9));
-
-    assert_eq!(advanced, claim);
 }

--- a/crates/akita-sumcheck/tests/drivers.rs
+++ b/crates/akita-sumcheck/tests/drivers.rs
@@ -6,8 +6,9 @@ use akita_serialization::{AkitaDeserialize, AkitaSerialize};
 use akita_sumcheck::{
     advance_eq_factored_claim, CompressedUniPoly, EqFactoredSumcheckInstanceProver,
     EqFactoredSumcheckInstanceProverExt, EqFactoredSumcheckInstanceVerifier,
-    EqFactoredSumcheckInstanceVerifierExt, EqFactoredUniPoly, SumcheckInstanceVerifier,
-    SumcheckInstanceVerifierExt, SumcheckProof, UniPoly,
+    EqFactoredSumcheckInstanceVerifierExt, EqFactoredUniPoly, SumcheckInstanceProver,
+    SumcheckInstanceProverExt, SumcheckInstanceVerifier, SumcheckInstanceVerifierExt,
+    SumcheckProof, UniPoly,
 };
 use akita_transcript::labels as tr_labels;
 use akita_transcript::{AkitaTranscript, Transcript};
@@ -422,6 +423,78 @@ fn sumcheck_validation_accepts_linear_round_messages() {
     };
 
     assert_eq!(proof.validate_round_messages(1, 3), Ok(()));
+}
+
+struct ZeroSumcheckInstance;
+
+impl SumcheckInstanceProver<F> for ZeroSumcheckInstance {
+    fn num_rounds(&self) -> usize {
+        4
+    }
+
+    fn degree_bound(&self) -> usize {
+        1
+    }
+
+    fn input_claim(&self) -> F {
+        F::zero()
+    }
+
+    fn compute_round_univariate(&mut self, _round: usize, _previous_claim: F) -> UniPoly<F> {
+        UniPoly::from_coeffs(Vec::new())
+    }
+
+    fn ingest_challenge(&mut self, _round: usize, _challenge: F) {}
+}
+
+impl SumcheckInstanceVerifier<F> for ZeroSumcheckInstance {
+    fn num_rounds(&self) -> usize {
+        SumcheckInstanceProver::num_rounds(self)
+    }
+
+    fn degree_bound(&self) -> usize {
+        SumcheckInstanceProver::degree_bound(self)
+    }
+
+    fn input_claim(&self) -> F {
+        F::zero()
+    }
+
+    fn expected_output_claim(&self, _challenges: &[F]) -> Result<F, AkitaError> {
+        Ok(F::zero())
+    }
+}
+
+#[test]
+fn empty_zero_polynomial_round_trips_through_standard_and_batched_sumcheck() {
+    let (proof, challenges, final_claim) = ZeroSumcheckInstance
+        .prove::<F, _, _>(&mut new_transcript(), sample_round)
+        .unwrap();
+    assert_eq!(final_claim, F::zero());
+    assert!(proof
+        .round_polys
+        .iter()
+        .all(|poly| poly.coeffs_except_linear_term == [F::zero()]));
+    assert_eq!(
+        ZeroSumcheckInstance.verify::<F, _, _>(&proof, &mut new_transcript(), sample_round),
+        Ok(challenges)
+    );
+
+    let (proof, challenges) = akita_sumcheck::prove_batched_sumcheck::<F, _, F, _>(
+        vec![&mut ZeroSumcheckInstance],
+        &mut new_transcript(),
+        |tr| tr.challenge_scalar(tr_labels::CHALLENGE_SUMCHECK_ROUND),
+    )
+    .unwrap();
+    assert_eq!(
+        akita_sumcheck::verify_batched_sumcheck::<F, _, F, _>(
+            &proof,
+            vec![&ZeroSumcheckInstance],
+            &mut new_transcript(),
+            |tr| tr.challenge_scalar(tr_labels::CHALLENGE_SUMCHECK_ROUND),
+        ),
+        Ok(challenges)
+    );
 }
 
 /// The eq-factored driver is not vulnerable and so is not guarded: an empty

--- a/crates/akita-sumcheck/tests/drivers.rs
+++ b/crates/akita-sumcheck/tests/drivers.rs
@@ -4,9 +4,10 @@ use akita_algebra::split_eq::GruenSplitEq;
 use akita_error::AkitaError;
 use akita_serialization::{AkitaDeserialize, AkitaSerialize};
 use akita_sumcheck::{
-    EqFactoredSumcheckInstanceProver, EqFactoredSumcheckInstanceProverExt,
-    EqFactoredSumcheckInstanceVerifier, EqFactoredSumcheckInstanceVerifierExt, EqFactoredUniPoly,
-    UniPoly,
+    advance_eq_factored_claim, CompressedUniPoly, EqFactoredSumcheckInstanceProver,
+    EqFactoredSumcheckInstanceProverExt, EqFactoredSumcheckInstanceVerifier,
+    EqFactoredSumcheckInstanceVerifierExt, EqFactoredUniPoly, SumcheckInstanceVerifier,
+    SumcheckInstanceVerifierExt, SumcheckProof, UniPoly,
 };
 use akita_transcript::labels as tr_labels;
 use akita_transcript::{AkitaTranscript, Transcript};
@@ -343,4 +344,97 @@ fn eq_factored_sumcheck_rejects_later_tampering_after_eq_factor_vanishes() {
     });
 
     assert_eq!(result, Err(AkitaError::InvalidProof));
+}
+
+/// Standard-driver instance whose input claim is deliberately inconsistent with
+/// its output claim: no honest proof exists, so any acceptance is a soundness
+/// break.
+struct FalseClaimInstance;
+
+impl SumcheckInstanceVerifier<F> for FalseClaimInstance {
+    fn num_rounds(&self) -> usize {
+        4
+    }
+
+    fn degree_bound(&self) -> usize {
+        3
+    }
+
+    fn input_claim(&self) -> F {
+        F::one()
+    }
+
+    fn expected_output_claim(&self, _challenges: &[F]) -> Result<F, AkitaError> {
+        Ok(F::zero())
+    }
+}
+
+fn empty_round_proof(num_rounds: usize) -> SumcheckProof<F> {
+    SumcheckProof {
+        round_polys: vec![
+            CompressedUniPoly {
+                coeffs_except_linear_term: Vec::new(),
+            };
+            num_rounds
+        ],
+    }
+}
+
+/// An empty compressed round message has `degree() == 0`, so it passes any
+/// degree bound, and `eval_from_hint` evaluates it to zero without reading the
+/// hint. Before the round-message validation, a proof of all-empty rounds drove
+/// the running claim to zero regardless of `input_claim`, and any instance whose
+/// expected output claim is zero accepted it.
+#[test]
+fn standard_sumcheck_rejects_empty_round_messages() {
+    let verifier = FalseClaimInstance;
+    let proof = empty_round_proof(verifier.num_rounds());
+    let mut transcript = new_transcript();
+
+    let result = verifier.verify::<F, _, _>(&proof, &mut transcript, sample_round);
+
+    assert_eq!(result, Err(AkitaError::InvalidProof));
+}
+
+/// The raw [`SumcheckProof::verify`] driver shares the same validation, so it
+/// rejects the same message before absorbing anything into the transcript.
+#[test]
+fn raw_sumcheck_driver_rejects_empty_round_messages() {
+    let proof = empty_round_proof(4);
+    let mut transcript = new_transcript();
+
+    let result = proof.verify::<F, _, _>(F::one(), 4, 3, &mut transcript, sample_round);
+
+    assert_eq!(result, Err(AkitaError::InvalidProof));
+}
+
+/// A single stored coefficient is a legitimate linear round message, even though
+/// `CompressedUniPoly::degree` reports `0` for it. Rejecting on `degree() == 0`
+/// instead of on an empty coefficient vector would reject honest proofs.
+#[test]
+fn sumcheck_validation_accepts_linear_round_messages() {
+    let linear = UniPoly::from_coeffs(vec![F::from_u64(3), F::from_u64(5)]).compress();
+    assert_eq!(linear.coeffs_except_linear_term.len(), 1);
+    assert_eq!(linear.degree(), 0);
+
+    let proof = SumcheckProof {
+        round_polys: vec![linear],
+    };
+
+    assert_eq!(proof.validate_round_messages(1, 3), Ok(()));
+}
+
+/// The eq-factored driver is not vulnerable and so is not guarded: an empty
+/// `q` message leaves the normalized claim untouched rather than zeroing it,
+/// because both the `tau`-scaled correction and the evaluation are zero.
+#[test]
+fn eq_factored_empty_round_message_preserves_the_claim() {
+    let empty = EqFactoredUniPoly::<F> {
+        coeffs_except_constant_term: Vec::new(),
+    };
+    let claim = F::from_u64(7);
+
+    let advanced = advance_eq_factored_claim(claim, F::from_u64(2), &empty, F::from_u64(9));
+
+    assert_eq!(advanced, claim);
 }

--- a/crates/akita-sumcheck/tests/drivers.rs
+++ b/crates/akita-sumcheck/tests/drivers.rs
@@ -501,15 +501,18 @@ fn compressed_constant_and_linear_rounds_require_degree_bound_one() {
     }
 }
 
-struct ZeroSumcheckInstance;
+struct ZeroSumcheckInstance {
+    num_rounds: usize,
+    degree_bound: usize,
+}
 
 impl SumcheckInstanceProver<F> for ZeroSumcheckInstance {
     fn num_rounds(&self) -> usize {
-        4
+        self.num_rounds
     }
 
     fn degree_bound(&self) -> usize {
-        1
+        self.degree_bound
     }
 
     fn input_claim(&self) -> F {
@@ -542,33 +545,61 @@ impl SumcheckInstanceVerifier<F> for ZeroSumcheckInstance {
 }
 
 #[test]
-fn empty_zero_polynomial_round_trips_through_standard_and_batched_sumcheck() {
-    let (proof, challenges, final_claim) = ZeroSumcheckInstance
-        .prove::<F, _, _>(&mut new_transcript(), sample_round)
-        .unwrap();
-    assert_eq!(final_claim, F::zero());
-    assert!(proof
-        .round_polys
-        .iter()
-        .all(|poly| poly.coeffs_except_linear_term == [F::zero()]));
-    assert_eq!(
-        ZeroSumcheckInstance.verify::<F, _, _>(&proof, &mut new_transcript(), sample_round),
-        Ok(challenges)
-    );
+fn standard_and_batched_provers_reject_zero_degree_rounds() {
+    let mut instance = ZeroSumcheckInstance {
+        num_rounds: 4,
+        degree_bound: 0,
+    };
+    assert!(matches!(
+        instance.prove::<F, _, _>(&mut new_transcript(), |_| panic!(
+            "invalid degree must reject before sampling"
+        )),
+        Err(AkitaError::InvalidInput(_))
+    ));
+    assert!(matches!(
+        akita_sumcheck::prove_batched_sumcheck::<F, _, F, _>(
+            vec![&mut instance],
+            &mut new_transcript(),
+            |_| panic!("invalid degree must reject before sampling"),
+        ),
+        Err(AkitaError::InvalidInput(_))
+    ));
+}
 
-    let (proof, challenges) = akita_sumcheck::prove_batched_sumcheck::<F, _, F, _>(
-        vec![&mut ZeroSumcheckInstance],
-        &mut new_transcript(),
-        |tr| tr.challenge_scalar(tr_labels::CHALLENGE_SUMCHECK_ROUND),
-    )
-    .unwrap();
-    assert_eq!(
-        akita_sumcheck::verify_batched_sumcheck::<F, _, F, _>(
-            &proof,
-            vec![&ZeroSumcheckInstance],
+#[test]
+fn empty_zero_polynomial_round_trips_through_standard_and_batched_sumcheck() {
+    for (num_rounds, degree_bound) in [(0, 0), (4, 1)] {
+        let mut instance = ZeroSumcheckInstance {
+            num_rounds,
+            degree_bound,
+        };
+        let (proof, challenges, final_claim) = instance
+            .prove::<F, _, _>(&mut new_transcript(), sample_round)
+            .unwrap();
+        assert_eq!(final_claim, F::zero());
+        assert!(proof
+            .round_polys
+            .iter()
+            .all(|poly| poly.coeffs_except_linear_term == [F::zero()]));
+        assert_eq!(
+            instance.verify::<F, _, _>(&proof, &mut new_transcript(), sample_round),
+            Ok(challenges)
+        );
+
+        let (proof, challenges) = akita_sumcheck::prove_batched_sumcheck::<F, _, F, _>(
+            vec![&mut instance],
             &mut new_transcript(),
             |tr| tr.challenge_scalar(tr_labels::CHALLENGE_SUMCHECK_ROUND),
-        ),
-        Ok(challenges)
-    );
+        )
+        .unwrap();
+        assert_eq!(
+            akita_sumcheck::verify_batched_sumcheck::<F, _, F, _>(
+                &proof,
+                vec![&instance],
+                &mut new_transcript(),
+                |tr| tr.challenge_scalar(tr_labels::CHALLENGE_SUMCHECK_ROUND),
+            ),
+            Ok(challenges)
+        );
+    }
 }

--- a/crates/akita-sumcheck/tests/drivers.rs
+++ b/crates/akita-sumcheck/tests/drivers.rs
@@ -409,20 +409,29 @@ fn raw_sumcheck_driver_rejects_empty_round_messages() {
     assert_eq!(result, Err(AkitaError::InvalidProof));
 }
 
-/// A single stored coefficient is a legitimate linear round message, even though
-/// `CompressedUniPoly::degree` reports `0` for it. Rejecting on `degree() == 0`
-/// instead of on an empty coefficient vector would reject honest proofs.
 #[test]
-fn sumcheck_validation_accepts_linear_round_messages() {
-    let linear = UniPoly::from_coeffs(vec![F::from_u64(3), F::from_u64(5)]).compress();
-    assert_eq!(linear.coeffs_except_linear_term.len(), 1);
-    assert_eq!(linear.degree(), 0);
+fn compressed_constant_and_linear_rounds_require_degree_bound_one() {
+    for coeffs in [vec![F::from_u64(3)], vec![F::from_u64(3), F::from_u64(5)]] {
+        let polynomial = UniPoly::from_coeffs(coeffs);
+        let claim = polynomial.evaluate(&F::zero()) + polynomial.evaluate(&F::one());
+        let challenge = F::from_u64(7);
+        let compressed = polynomial.compress();
+        assert_eq!(compressed.degree(), 1);
+        let proof = SumcheckProof {
+            round_polys: vec![compressed],
+        };
 
-    let proof = SumcheckProof {
-        round_polys: vec![linear],
-    };
-
-    assert_eq!(proof.validate_round_messages(1, 3), Ok(()));
+        assert_eq!(
+            proof.verify::<F, _, _>(claim, 1, 1, &mut new_transcript(), |_| Ok(challenge)),
+            Ok((polynomial.evaluate(&challenge), vec![challenge]))
+        );
+        assert!(matches!(
+            proof.verify::<F, _, _>(claim, 1, 0, &mut new_transcript(), |_| panic!(
+                "invalid degree must reject before sampling"
+            )),
+            Err(AkitaError::InvalidInput(_))
+        ));
+    }
 }
 
 struct ZeroSumcheckInstance;

--- a/crates/akita-sumcheck/tests/drivers.rs
+++ b/crates/akita-sumcheck/tests/drivers.rs
@@ -347,9 +347,7 @@ fn eq_factored_sumcheck_rejects_later_tampering_after_eq_factor_vanishes() {
     assert_eq!(result, Err(AkitaError::InvalidProof));
 }
 
-/// Standard-driver instance whose input claim is deliberately inconsistent with
-/// its output claim: no honest proof exists, so any acceptance is a soundness
-/// break.
+/// An inconsistent claim for the identically zero polynomial.
 struct FalseClaimInstance;
 
 impl SumcheckInstanceVerifier<F> for FalseClaimInstance {
@@ -370,43 +368,109 @@ impl SumcheckInstanceVerifier<F> for FalseClaimInstance {
     }
 }
 
-fn empty_round_proof(num_rounds: usize) -> SumcheckProof<F> {
-    SumcheckProof {
-        round_polys: vec![
-            CompressedUniPoly {
-                coeffs_except_linear_term: Vec::new(),
-            };
-            num_rounds
-        ],
+fn assert_rounds_rejected_before_replay(proof: &SumcheckProof<F>, expected: AkitaError) {
+    let verifier = FalseClaimInstance;
+    for raw_driver in [false, true] {
+        let mut transcript = new_transcript();
+        let mut samples = 0;
+        let sample = |_: &mut AkitaTranscript<F>| {
+            samples += 1;
+            Ok(F::one())
+        };
+        let result = if raw_driver {
+            proof
+                .verify::<F, _, _>(
+                    verifier.input_claim(),
+                    verifier.num_rounds(),
+                    verifier.degree_bound(),
+                    &mut transcript,
+                    sample,
+                )
+                .map(|_| ())
+        } else {
+            verifier
+                .verify::<F, _, _>(proof, &mut transcript, sample)
+                .map(|_| ())
+        };
+        assert_eq!(result, Err(expected.clone()));
+        assert_eq!(samples, 0);
+        assert_eq!(
+            transcript.challenge_bytes(b"test/rejected-round-state", 32),
+            new_transcript().challenge_bytes(b"test/rejected-round-state", 32)
+        );
     }
 }
 
-/// An empty compressed round message has `degree() == 0`, so it passes any
-/// degree bound, and `eval_from_hint` evaluates it to zero without reading the
-/// hint. Before the round-message validation, a proof of all-empty rounds drove
-/// the running claim to zero regardless of `input_claim`, and any instance whose
-/// expected output claim is zero accepted it.
 #[test]
-fn standard_sumcheck_rejects_empty_round_messages() {
+fn standard_sumcheck_rejects_malformed_messages_at_every_round() {
     let verifier = FalseClaimInstance;
-    let proof = empty_round_proof(verifier.num_rounds());
-    let mut transcript = new_transcript();
-
-    let result = verifier.verify::<F, _, _>(&proof, &mut transcript, sample_round);
-
-    assert_eq!(result, Err(AkitaError::InvalidProof));
+    for round in 0..verifier.num_rounds() {
+        for stored_coefficients in [0, verifier.degree_bound() + 1] {
+            let mut proof = SumcheckProof {
+                round_polys: vec![
+                    UniPoly::from_coeffs(vec![F::zero()]).compress();
+                    verifier.num_rounds()
+                ],
+            };
+            proof.round_polys[round] = CompressedUniPoly {
+                coeffs_except_linear_term: vec![F::one(); stored_coefficients],
+            };
+            let error = if stored_coefficients == 0 {
+                AkitaError::InvalidProof
+            } else {
+                AkitaError::InvalidInput("sumcheck round poly degree 4 exceeds bound 3".into())
+            };
+            assert_rounds_rejected_before_replay(&proof, error);
+        }
+    }
 }
 
-/// The raw [`SumcheckProof::verify`] driver shares the same validation, so it
-/// rejects the same message before absorbing anything into the transcript.
 #[test]
-fn raw_sumcheck_driver_rejects_empty_round_messages() {
-    let proof = empty_round_proof(4);
-    let mut transcript = new_transcript();
+fn standard_sumcheck_rejects_wrong_round_counts_before_replay() {
+    let expected = FalseClaimInstance.num_rounds();
+    for actual in [0, expected - 1, expected + 1] {
+        let proof = SumcheckProof {
+            round_polys: vec![UniPoly::from_coeffs(vec![F::zero()]).compress(); actual],
+        };
+        assert_rounds_rejected_before_replay(&proof, AkitaError::InvalidSize { expected, actual });
+    }
+}
 
-    let result = proof.verify::<F, _, _>(F::one(), 4, 3, &mut transcript, sample_round);
+#[test]
+fn zero_round_sumcheck_preserves_the_claim() {
+    let proof = SumcheckProof::<F> {
+        round_polys: Vec::new(),
+    };
+    let claim = F::from_u64(7);
+    assert_eq!(
+        proof.verify::<F, _, _>(claim, 0, 0, &mut new_transcript(), |_| panic!(
+            "no round to sample"
+        )),
+        Ok((claim, Vec::new()))
+    );
+}
 
-    assert_eq!(result, Err(AkitaError::InvalidProof));
+#[test]
+fn batched_sumcheck_rejects_an_empty_last_round() {
+    let verifier = FalseClaimInstance;
+    let mut proof = SumcheckProof {
+        round_polys: vec![UniPoly::from_coeffs(vec![F::zero()]).compress(); verifier.num_rounds()],
+    };
+    proof
+        .round_polys
+        .last_mut()
+        .unwrap()
+        .coeffs_except_linear_term
+        .clear();
+    assert_eq!(
+        akita_sumcheck::verify_batched_sumcheck::<F, _, F, _>(
+            &proof,
+            vec![&verifier],
+            &mut new_transcript(),
+            |tr| tr.challenge_scalar(tr_labels::CHALLENGE_SUMCHECK_ROUND),
+        ),
+        Err(AkitaError::InvalidProof)
+    );
 }
 
 #[test]

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -38,6 +38,7 @@ name = "akita-fuzz"
 version = "0.0.0"
 dependencies = [
  "akita-serialization",
+ "akita-sumcheck",
  "akita-transcript",
  "akita-types",
  "jolt-field",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -13,6 +13,7 @@ jolt-field = { version = "=0.1.0", git = "https://github.com/a16z/jolt", rev = "
   "solinas",
 ] }
 akita-serialization = { path = "../crates/akita-serialization" }
+akita-sumcheck = { path = "../crates/akita-sumcheck" }
 akita-transcript = { path = "../crates/akita-transcript" }
 akita-types = { path = "../crates/akita-types" }
 libfuzzer-sys = "0.4.12"
@@ -27,6 +28,13 @@ bench = false
 [[bin]]
 name = "transcript_labels"
 path = "fuzz_targets/transcript_labels.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "sumcheck_rounds"
+path = "fuzz_targets/sumcheck_rounds.rs"
 test = false
 doc = false
 bench = false

--- a/fuzz/fuzz_targets/sumcheck_rounds.rs
+++ b/fuzz/fuzz_targets/sumcheck_rounds.rs
@@ -1,0 +1,56 @@
+#![no_main]
+
+use akita_sumcheck::{CompressedUniPoly, SumcheckProof};
+use akita_transcript::{AkitaTranscript, Transcript};
+use jolt_field::{Prime128Offset275 as F, Ring};
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let [rounds, degree, claim, data @ ..] = data else {
+        return;
+    };
+    let num_rounds = usize::from(rounds % 5);
+    let degree_bound = usize::from(degree % 5);
+    let proof = SumcheckProof {
+        // Bound both the number and width of typed round messages. A chunk's
+        // first byte selects its stored coefficient count, including zero.
+        round_polys: data
+            .chunks_exact(6)
+            .take(5)
+            .map(|chunk| CompressedUniPoly {
+                coeffs_except_linear_term: chunk[1..]
+                    .iter()
+                    .take(usize::from(chunk[0] % 6))
+                    .map(|&coefficient| F::from_u64(u64::from(coefficient)))
+                    .collect(),
+            })
+            .collect(),
+    };
+    let valid_shape = proof.round_polys.len() == num_rounds
+        && proof
+            .round_polys
+            .iter()
+            .all(|poly| (1..=degree_bound).contains(&poly.coeffs_except_linear_term.len()));
+    let mut transcript = AkitaTranscript::<F>::new(b"fuzz/sumcheck-rounds");
+    let mut samples = 0;
+    let result = proof.verify::<F, _, _>(
+        F::from_u64(u64::from(*claim)),
+        num_rounds,
+        degree_bound,
+        &mut transcript,
+        |tr| {
+            samples += 1;
+            Ok(tr.challenge_scalar(b"round"))
+        },
+    );
+    assert_eq!(result.is_ok(), valid_shape);
+    if valid_shape {
+        assert_eq!(samples, num_rounds);
+    } else {
+        assert_eq!(samples, 0);
+        assert_eq!(
+            transcript.challenge_bytes(b"state", 32),
+            AkitaTranscript::<F>::new(b"fuzz/sumcheck-rounds").challenge_bytes(b"state", 32)
+        );
+    }
+});


### PR DESCRIPTION
Empty ordinary sumcheck messages bypassed the degree check and made `eval_from_hint` return zero without using the incoming claim. A four-round proof of empty messages could therefore turn input claim `1` into final claim `0` and pass a generic verifier whose expected output was zero.

This is reachable through caller-constructed typed proofs. The Jolt byte decoder already enforces canonical message widths. No end-to-end PCS forgery has been demonstrated.

The verifier now shares one round-message validator across the standard and raw drivers. It rejects wrong round counts, empty messages, and excessive degrees before those drivers change the transcript. Batched verification reaches the same validation through the raw driver.

The follow-up fixes keep the producers and verifier consistent:

- Compress an empty zero polynomial to `[0]`, so standard and batched provers emit messages their verifier accepts.
- Estimate compressed degree conservatively: one stored coefficient can represent a linear polynomial. Ordinary rounds therefore require a degree bound of at least one, including constant rounds. Standard and batched producers reject nonzero-round configurations without a positive degree bound. Zero-round proofs remain valid and preserve the input claim.
- Keep empty eq-factored constant messages valid: their omitted constant coefficient is recovered from the normalized claim, so they preserve that claim.
- Keep validation internal, exercise it through the public drivers, and consolidate the redundant eq-factored test.

Regression coverage includes every malformed-round position, late excessive degrees, wrong round counts, unchanged transcript state and zero sampler calls on rejection, zero-polynomial round-trips through both producers, linear-degree bounds, batched rejection, and malformed typed PCS proofs. The Book documents the encoding and degree contracts. A bounded fuzz target exercises typed round validation and transcript preservation.

Validation completed locally:

- Both full CI-fidelity Nextest shards on `3dff33c4`: 1,780 tests passed, plus focused sumcheck/algebra tests and the typed PCS regression.
- All three CI Clippy feature configurations with `-D warnings`.
- Formatting, dependency/field identity checks, Rust line limits, all 84 Python tests, typos, and documentation guardrails including the Book build.
- Six mutation checks: the tests fail if empty validation is removed, only the first round is checked, validation follows claim absorption, empty zero encodings are restored, linear degree is underestimated, or the batched zero-degree check is removed.
- 4,041,404 native ASan fuzz executions without a failure.

Schedule regeneration completed for all 13 families with no artifact drift. Final GitHub validation on `3dff33c4` completed: 47 successful checks, one skipped Book deployment check, and no failures or pending checks. Individual CodeQL analyses, both transcript backends, portability, Jolt integration, fuzzing, and the complete schedule validation job passed. All 13 benchmark profiles passed with unchanged proof/setup sizes.
