### PR TITLE
fix(estimator): use q as the Euclidean SIS triviality bound

### DIFF
--- a/crates/akita-sis-estimator/src/euclidean.rs
+++ b/crates/akita-sis-estimator/src/euclidean.rs
@@ -1,14 +1,14 @@
 //! Euclidean-norm SIS lattice cost.
 
 use num_bigint::BigUint;
-use num_traits::One;
+use num_traits::FromPrimitive;
 
 use crate::{
     config::{EstimateConfig, ReductionCostModel},
     cost::{CostValue, EstimateTag, LatticeCost},
     error::{EstimatorError, Result},
     math::log2_biguint,
-    params::SisParameters,
+    params::{Bound, SisParameters},
     reduction::{adps16_log2_cost, beta as beta_from_delta, delta, validate_euclidean_reduction},
 };
 
@@ -18,7 +18,7 @@ pub fn cost_euclidean(params: &SisParameters, config: &EstimateConfig) -> Result
     if length_bound_trivially_easy(params) {
         return Err(EstimatorError::InvalidParameter {
             field: "length_bound",
-            reason: "SIS trivially easy: length_bound must be below (q - 1) / 2".to_string(),
+            reason: "SIS trivially easy: Euclidean length_bound must be below q".to_string(),
         });
     }
 
@@ -99,8 +99,18 @@ fn opt_sis_dimension(params: &SisParameters, m: u64, log_q: f64) -> Result<u64> 
 }
 
 fn length_bound_trivially_easy(params: &SisParameters) -> bool {
-    let half_q_log2 = log2_biguint(&(params.q.clone() - BigUint::one())) - 1.0;
-    params.length_bound.log2() >= half_q_log2
+    // Standard Euclidean SIS has the unconditional solution q * e_i, whose
+    // length is q.  The centered-representative boundary (q - 1) / 2 is not a
+    // triviality threshold for this norm.
+    match &params.length_bound {
+        Bound::Integer(value) => value >= &params.q,
+        Bound::Float(value) => BigUint::from_f64(*value).is_some_and(|value| value >= params.q),
+        Bound::Rational {
+            numerator,
+            denominator,
+        } => numerator >= &(&params.q * denominator),
+        Bound::SqrtInteger(radicand) => radicand >= &(&params.q * &params.q),
+    }
 }
 
 fn length_bound_exceeds_euclidean_lower_bound(params: &SisParameters, d: u64, log_q: f64) -> bool {
@@ -194,5 +204,44 @@ mod tests {
             cost.rop,
             CostValue::finite_log2(adps16_log2_cost(beta, Adps16Mode::Quantum))
         );
+    }
+
+    #[test]
+    fn euclidean_triviality_boundary_is_q() {
+        let q = akita_q32();
+        let params = |length_bound| {
+            SisParameters::try_new(32, q.clone(), Some(128), length_bound, SisNorm::Euclidean)
+                .unwrap()
+        };
+
+        assert!(!length_bound_trivially_easy(&params(Bound::Integer(
+            &q - BigUint::from(1u8)
+        ))));
+        assert!(length_bound_trivially_easy(&params(Bound::Integer(
+            q.clone()
+        ))));
+
+        assert!(!length_bound_trivially_easy(&params(Bound::Rational {
+            numerator: &q * BigUint::from(2u8) - BigUint::from(1u8),
+            denominator: BigUint::from(2u8),
+        })));
+        assert!(length_bound_trivially_easy(&params(Bound::Rational {
+            numerator: &q * BigUint::from(2u8),
+            denominator: BigUint::from(2u8),
+        })));
+
+        assert!(!length_bound_trivially_easy(&params(Bound::SqrtInteger(
+            &q * &q - BigUint::from(1u8)
+        ))));
+        assert!(length_bound_trivially_easy(&params(Bound::SqrtInteger(
+            &q * &q
+        ))));
+
+        assert!(!length_bound_trivially_easy(&params(Bound::Float(
+            3_000_000_000.0
+        ))));
+        assert!(length_bound_trivially_easy(&params(Bound::Float(
+            4_294_967_197.0
+        ))));
     }
 }


### PR DESCRIPTION
## Summary

This PR corrects Akita's Euclidean-SIS triviality boundary from `(q - 1) / 2` to `q`.

For standard Euclidean SIS, the unconditional modular solution is `q * e_i`, whose L2 norm is exactly `q`. Crossing the centered-representative boundary `(q - 1) / 2` does not by itself yield a trivial SIS solution. The upstream lattice estimator made the same correction in [malb/lattice-estimator#218](https://github.com/malb/lattice-estimator/pull/218), following the analysis in [malb/lattice-estimator#162](https://github.com/malb/lattice-estimator/issues/162).

### Current diff metadata

- Base: `c2a70dc68c489d28dfaba7bf1cc897cd9823e107` (`main` at the final branch update)
- Head: `6c1137d8933f81c36a84bb66579b2d2d3f15ce4e`
- Commits unique to the branch: 3, including the merge from current `main`
- Files changed: 2
- Diff: 160 insertions, 10 deletions

## Motivation

The previous Euclidean estimator rejected every collision bound at or above `(q - 1) / 2` before running the lattice-cost model. That cutoff confuses the centered modular-representative interval with the norm of a trivial Euclidean-SIS witness and can falsely reject secure parameter candidates whose bounds lie between `q / 2` and `q`.

## Changes

- Use `length_bound >= q` as the Euclidean triviality predicate.
- Compare each `Bound` representation without log-space boundary rounding:
  - integer bounds compare directly with `q`;
  - rational bounds compare the numerator with `q * denominator`;
  - square-root bounds compare the radicand with `q^2`;
  - finite positive floating bounds compare their integer floor with `q`.
- Update the rejection message to name the Euclidean `q` boundary.
- Exercise both public estimator entry points with a finite bound between `q / 2` and `q`, and reject public inputs at and above `q`.
- Cover q32 floating values immediately below, at, and above the cutoff; a modulus above exact `f64` integer precision; and exact q64/q128 integer and square-root boundaries.
- Correct stale public API documentation that described the Euclidean estimator as unimplemented.

The infinity-norm estimator is intentionally unchanged; its existing `(q - 1) / 2` policy is a separate norm-specific path.

## Generated artifacts

Generated L2 tables and schedule artifacts are intentionally unchanged. Existing table entries remain conservative, and all current q32 schedules lie below the affected bound range. Regenerating the complete offline L2 table could add newly supportable large-bound rows, but is not required to correct the estimator predicate or preserve the security of existing schedules.

## Security impact

This removes false negatives from Euclidean parameter selection. It does not weaken the lattice cost calculation or accept the unconditional `q * e_i` solution: bounds at or above `q` continue to be rejected before estimation.

## Validation

Validated locally at `6c1137d8933f81c36a84bb66579b2d2d3f15ce4e`:

- `cargo test -p akita-sis-estimator --lib --tests` — 105 tests passed;
- estimator Clippy across all targets and features with warnings denied;
- repository Rust formatting;
- Rust file-line self-tests and repository line-cap check;
- diff whitespace check.

Fresh repository CI at the current head completed with 47 checks passed, one expected Book deployment skip, and no failures.

## Reviewer map

- `crates/akita-sis-estimator/src/euclidean.rs`: exact boundary predicate, diagnostic, public-path tests, and representation/precision boundary tests.
- `crates/akita-sis-estimator/src/lib.rs`: corrected public Euclidean API error documentation.
